### PR TITLE
fix: point offset sign

### DIFF
--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2380,9 +2380,9 @@ namespace andywiecko.BurstTriangulator
                     {
                         continue;
                     }
-                    outputTriangles.Add(t0 - 3 - pointsOffset[t0]);
-                    outputTriangles.Add(t1 - 3 - pointsOffset[t1]);
-                    outputTriangles.Add(t2 - 3 - pointsOffset[t2]);
+                    outputTriangles.Add(t0 - 3 + pointsOffset[t0]);
+                    outputTriangles.Add(t1 - 3 + pointsOffset[t1]);
+                    outputTriangles.Add(t2 - 3 + pointsOffset[t2]);
                 }
             }
 


### PR DESCRIPTION
Fix the sign in `CleanupJob` with respect to `pointsOffset` introduced @c8a20bf.