### PR TITLE
Reduce code complexity

### DIFF
--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -354,8 +354,9 @@ namespace andywiecko.BurstTriangulator
                 }.Execute();
                 MarkerDelaunayTriangulation.End();
 
-                var internalConstraints = new NativeList<Edge>(localPositions.Length, Allocator.Temp);
+                NativeList<Edge> internalConstraints = default;
                 if (input.ConstraintEdges.IsCreated) {
+                    internalConstraints = new NativeList<Edge>(localPositions.Length, Allocator.Temp);
                     MarkerConstrainEdges.Begin();
                     new ConstrainEdgesJob {
                         status = output.Status,
@@ -390,7 +391,7 @@ namespace andywiecko.BurstTriangulator
                         outputPositions = localPositions,
                         circles = circles,
                         halfedges = halfEdges,
-                        constraints = input.ConstraintEdges.IsCreated ? internalConstraints : default,
+                        constraints = internalConstraints,
                     }.Execute();
                     MarkerRefineMesh.End();
                 }

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -366,7 +366,14 @@ namespace andywiecko.BurstTriangulator
                 using var halfedges = new NativeList<int>(localPositions.Length, Allocator.Temp);
                 var triangles = output.Triangles;
                 using var circles = new NativeList<Circle>(localPositions.Length, Allocator.Temp);
-                new DelaunayTriangulationJob(output.Status, localPositions.AsArray(), triangles, halfedges).Execute();
+                new DelaunayTriangulationJob {
+                    status = output.Status,
+                    positions = localPositions.AsArray(),
+                    triangles = triangles,
+                    halfedges = halfedges,
+                    hullStart = int.MaxValue,
+                    c = float.MaxValue
+                }.Execute();
                 MarkerDelaunayTriangulation.End();
 
                 NativeArray<Edge> internalConstraints = default;
@@ -539,25 +546,6 @@ namespace andywiecko.BurstTriangulator
                 public DistComparer(NativeArray<float> dist) => this.dist = dist;
                 public int Compare(int x, int y) => dist[x].CompareTo(dist[y]);
             }
-
-            public DelaunayTriangulationJob(NativeReference<Status> status, NativeArray<float2> positions, NativeList<int> triangles, NativeList<int> halfedges) {
-                this.status = status;
-                this.positions = positions;
-                this.triangles = triangles;
-                this.halfedges = halfedges;
-                hullStart = int.MaxValue;
-                c = float.MaxValue;
-                ids = default;
-                dists = default;
-                hullNext = default;
-                hullPrev = default;
-                hullTri = default;
-                hullHash = default;
-                hashSize = default;
-                EDGE_STACK = default;
-                trianglesLen = 0;
-            }
-
 
             public NativeReference<Status> status;
             [ReadOnly]

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -394,14 +394,13 @@ namespace andywiecko.BurstTriangulator
                     }
                 }
 
-                if (refineMesh) {
+                if (refineMesh && output.Status.Value == Status.OK) {
                     MarkerRefineMesh.Begin();
                     new RefineMeshJob() {
                         restoreBoundary = restoreBoundary,
                         maximumArea2 = 2 * refinementThresholdArea * localTransformation.areaScalingFactor,
                         minimumAngle = refinementThresholdAngle,
                         D = concentricShellsParameter,
-                        status = output.Status,
                         triangles = triangles,
                         outputPositions = localPositions,
                         circles = circles,
@@ -1380,7 +1379,6 @@ namespace andywiecko.BurstTriangulator
             public float maximumArea2;
             public float minimumAngle;
             public float D;
-            public NativeReference<Status>.ReadOnly status;
             public NativeList<int> triangles;
             public NativeList<float2> outputPositions;
             public NativeList<Circle> circles;
@@ -1403,11 +1401,6 @@ namespace andywiecko.BurstTriangulator
 
             public void Execute()
             {
-                if (status.Value != Status.OK)
-                {
-                    return;
-                }
-
                 initialPointsCount = outputPositions.Length;
                 circles.Length = triangles.Length / 3;
                 for (int tId = 0; tId < triangles.Length / 3; tId++)

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -13,8 +13,14 @@ using UnityEngine.Assertions;
 
 namespace andywiecko.BurstTriangulator
 {
-    /** Supports rotation, scaling and translation in 2D */
-    public struct AffineTransform2D {
+    /** Supports rotation, scaling and translation in 2D.
+     *
+     * The transformation is defined as first a translation, and then rotation+scaling.
+     * The order is important for floating point accuracy reasons. This is often used to
+     * move points from very far away back to the origin. If we would have done the rotation+scaling first (like in a standard matrix multiplication),
+     * the translation might have to be much larger, which can lead to floating point inaccuracies.
+     */
+    struct AffineTransform2D {
         float2x2 rotScale;
         float2 translation;
 
@@ -62,7 +68,7 @@ namespace andywiecko.BurstTriangulator
             for (int i = 0; i < points.Length; i++) outPoints[i] = math.mul(invRotScale, points[i]) - translation;
         }
 
-		public override string ToString() => $"RigidTransform(rotScale={rotScale}, translation={translation})";
+		public override string ToString() => $"AffineTransform2D(translation={translation}, rotScale={rotScale})";
 	}
 
     public class Triangulator : IDisposable

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -368,13 +368,14 @@ namespace andywiecko.BurstTriangulator
                     }.Execute();
                     MarkerConstrainEdges.End();
 
-                if (input.ConstraintEdges.IsCreated && (localHoles.IsCreated || restoreBoundary)) {
-                    MarkerPlantSeeds.Begin();
-                    var seedPlanter = new SeedPlanter(output.Status, triangles, localPositions, circles, internalConstraints, halfEdges);
-                    if (localHoles.IsCreated) seedPlanter.PlantHoleSeeds(localHoles);
-                    if (restoreBoundary) seedPlanter.PlantBoundarySeeds();
-                    seedPlanter.Finish();
-                    MarkerPlantSeeds.End();
+                    if (localHoles.IsCreated || restoreBoundary) {
+                        MarkerPlantSeeds.Begin();
+                        var seedPlanter = new SeedPlanter(output.Status, triangles, localPositions, circles, internalConstraints, halfEdges);
+                        if (localHoles.IsCreated) seedPlanter.PlantHoleSeeds(localHoles);
+                        if (restoreBoundary) seedPlanter.PlantBoundarySeeds();
+                        seedPlanter.Finish();
+                        MarkerPlantSeeds.End();
+                    }
                 }
 
                 if (refineMesh) {

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -413,7 +413,7 @@ namespace andywiecko.BurstTriangulator
                 MarkerInverseTransformation.Begin();
                 // If an output position list was provided, we need to transform the local positions back to world space.
                 // If none was provided, we can skip this step, as the user doesn't need it.
-                if (output.Positions.IsCreated && preprocessor != Preprocessor.None) {
+                if (preprocessor != Preprocessor.None) {
                     localTransformation.InverseTransform(localPositions.AsArray(), output.Positions.AsArray());
                 }
                 MarkerInverseTransformation.End();

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -386,7 +386,7 @@ namespace andywiecko.BurstTriangulator
                         triangles = triangles.AsArray(),
                         inputConstraintEdges = input.ConstraintEdges,
                         internalConstraints = internalConstraints,
-                        halfedges = halfedges.AsArray(),
+                        halfedges = halfedges,
                         maxIters = sloanMaxIters,
                     }.Execute();
                     MarkerConstrainEdges.End();
@@ -1042,7 +1042,7 @@ namespace andywiecko.BurstTriangulator
             [ReadOnly]
             public NativeArray<int> inputConstraintEdges;
             public NativeArray<Edge> internalConstraints;
-            public NativeArray<int> halfedges;
+            public NativeList<int> halfedges;
             public int maxIters;
 
             [NativeDisableContainerSafetyRestriction]

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -373,15 +373,15 @@ namespace andywiecko.BurstTriangulator
                 if (input.ConstraintEdges.IsCreated) {
                     internalConstraints = new NativeArray<Edge>(input.ConstraintEdges.Length/2, Allocator.Temp);
                     MarkerConstrainEdges.Begin();
-                    new ConstrainEdgesJob(
-                        status: output.Status,
-                        positions: localPositions.AsArray(),
-                        triangles: triangles.AsArray(),
-                        inputConstraintEdges: input.ConstraintEdges,
-                        internalConstraints: internalConstraints,
-                        halfedges: halfedges.AsArray(),
-                        maxIters: sloanMaxIters
-                    ).Execute();
+                    new ConstrainEdgesJob {
+                        status = output.Status,
+                        positions = localPositions.AsArray(),
+                        triangles = triangles.AsArray(),
+                        inputConstraintEdges = input.ConstraintEdges,
+                        internalConstraints = internalConstraints,
+                        halfedges = halfedges.AsArray(),
+                        maxIters = sloanMaxIters,
+                    }.Execute();
                     MarkerConstrainEdges.End();
 
                     if (localHoles.IsCreated || restoreBoundary) {
@@ -394,19 +394,20 @@ namespace andywiecko.BurstTriangulator
                     }
                 }
 
-                if (refineMesh && output.Status.Value == Status.OK) {
+                if (refineMesh) {
                     MarkerRefineMesh.Begin();
-                    new RefineMeshJob(
-                        triangles: triangles,
-                        outputPositions: localPositions,
-                        circles: circles,
-                        halfedges: halfedges,
-                        constraints: internalConstraints,
-                        restoreBoundary: restoreBoundary,
-                        maximumArea2: 2 * refinementThresholdArea * localTransformation.areaScalingFactor,
-                        minimumAngle: refinementThresholdAngle,
-                        D: concentricShellsParameter
-                    ).Execute();
+                    new RefineMeshJob() {
+                        restoreBoundary = restoreBoundary,
+                        maximumArea2 = 2 * refinementThresholdArea * localTransformation.areaScalingFactor,
+                        minimumAngle = refinementThresholdAngle,
+                        D = concentricShellsParameter,
+                        status = output.Status,
+                        triangles = triangles,
+                        outputPositions = localPositions,
+                        circles = circles,
+                        halfedges = halfedges,
+                        constraints = internalConstraints,
+                    }.Execute();
                     MarkerRefineMesh.End();
                 }
 
@@ -1064,28 +1065,6 @@ namespace andywiecko.BurstTriangulator
             [NativeDisableContainerSafetyRestriction]
             private NativeArray<int> pointToHalfedge;
 
-            public ConstrainEdgesJob(
-                NativeReference<Status> status,
-                NativeArray<float2> positions,
-                NativeArray<int> triangles,
-                NativeArray<int> inputConstraintEdges,
-                NativeArray<Edge> internalConstraints,
-                NativeArray<int> halfedges,
-                int maxIters
-            )
-            {
-                this.status = status;
-                this.positions = positions;
-                this.triangles = triangles;
-                this.inputConstraintEdges = inputConstraintEdges;
-                this.internalConstraints = internalConstraints;
-                this.halfedges = halfedges;
-                this.maxIters = maxIters;
-                intersections = default;
-                unresolvedIntersections = default;
-                pointToHalfedge = default;
-            }
-
             public void Execute()
             {
                 if (status.Value != Status.OK)
@@ -1401,6 +1380,7 @@ namespace andywiecko.BurstTriangulator
             public float maximumArea2;
             public float minimumAngle;
             public float D;
+            public NativeReference<Status>.ReadOnly status;
             public NativeList<int> triangles;
             public NativeList<float2> outputPositions;
             public NativeList<Circle> circles;
@@ -1421,38 +1401,13 @@ namespace andywiecko.BurstTriangulator
             [NativeDisableContainerSafetyRestriction]
             private NativeList<bool> constrainedHalfedges;
 
-            public RefineMeshJob (
-                NativeList<int> triangles,
-                NativeList<float2> outputPositions,
-                NativeList<Circle> circles,
-                NativeList<int> halfedges,
-                NativeArray<Edge> constraints,
-                bool restoreBoundary,
-                float maximumArea2,
-                float minimumAngle,
-                float D
-            )
-            {
-                this.restoreBoundary = restoreBoundary;
-                this.maximumArea2 = maximumArea2;
-                this.minimumAngle = minimumAngle;
-                this.D = D;
-                this.triangles = triangles;
-                this.outputPositions = outputPositions;
-                this.circles = circles;
-                this.halfedges = halfedges;
-                this.constraints = constraints;
-                trianglesQueue = default;
-                badTriangles = default;
-                pathPoints = default;
-                pathHalfedges = default;
-                visitedTriangles = default;
-                constrainedHalfedges = default;
-                initialPointsCount = 0;
-            }
-
             public void Execute()
             {
+                if (status.Value != Status.OK)
+                {
+                    return;
+                }
+
                 initialPointsCount = outputPositions.Length;
                 circles.Length = triangles.Length / 3;
                 for (int tId = 0; tId < triangles.Length / 3; tId++)


### PR DESCRIPTION
This PR refactors the package a bit.

The primary changes are:

* Changes the triangulator to schedule a single job, instead of multiple smaller ones. Since all previous jobs depended on each other in sequence, there was no benefit to scheduling smaller jobs, and it made resource management harder. Now, temporary arrays can be created using the Temp allocator. Performance wise, this is no significant change. It might be a bit faster, but I haven't done any extensive analysis. I'm planning to use this to triangulate *a lot* of meshes that have a very low point count, and then more jobs might very well have caused significant overhead. Mostly I did this to make the code shorter and clearer, though.
* The preprocessor transformations code has been greatly simplified. All transformations are now represented by a AffineTransform2D struct, and a whole bunch of jobs have been removed. This PR reduces the line count of the Triangulator.cs script by about 200 lines.
* The seed placer has been changed into a helper struct, which makes it nicer and cleaner to use imo. I initially did it to get rid of the generics, but I see you also got rid of the generics before I had time to post this PR.
* Added some code comments from the delunator repository. Not sure why they were removed when you ported the code, as they are really helpful.

I have tried to keep to your code style. But I don't have an auto-formatter for it, so it might be a bit inconsistent.

The external API and behavior is unchanged (modulo tiny changes in floating point handling). All existing tests pass without changes.