### PR TITLE
Add support for integer coordinates

### DIFF
--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2567,28 +2567,28 @@ namespace andywiecko.BurstTriangulator
 
         public AffineTransform2D CalculatePCATransformation(NativeArray<int2> positions)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException("Cannot use pre-processing for integer coordinates");
         }
 
         public AffineTransform2D CalculateLocalTransformation(NativeArray<int2> positions)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException("Cannot use pre-processing for integer coordinates");
         }
 
         public void Transform (AffineTransform2D transform, NativeArray<int2> points) {
             if (transform != AffineTransform2D.identity) {
-                throw new NotImplementedException();
+                throw new InvalidOperationException("Cannot use pre-processing for integer coordinates");
             }
         }
         public void Transform (AffineTransform2D transform, [NoAlias] NativeArray<int2> points, [NoAlias] NativeArray<int2> outPoints) {
             if (transform != AffineTransform2D.identity) {
-                throw new NotImplementedException();
+                throw new InvalidOperationException("Cannot use pre-processing for integer coordinates");
             }
             outPoints.CopyFrom(points);
         }
         public void InverseTransform (AffineTransform2D transform, [NoAlias] NativeArray<int2> points, [NoAlias] NativeArray<int2> outPoints) {
             if (transform != AffineTransform2D.identity) {
-                throw new NotImplementedException();
+                throw new InvalidOperationException("Cannot use pre-processing for integer coordinates");
             }
             outPoints.CopyFrom(points);
         }

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2554,6 +2554,7 @@ namespace andywiecko.BurstTriangulator
             CCW(a, c, b) != 0 && CCW(a, c, d) != 0 && CCW(b, d, a) != 0 && CCW(b, d, c) != 0 &&
             CCW(a, c, b) != CCW(a, c, d) && CCW(b, d, a) != CCW(b, d, c);
 
+        // For most purposes, all integer coordinates are valid, but e.g. the InCircle method may fail with very large coordinates, I think.
         public bool IsValidCoordinate(int2 v) => math.all(v <= (1 << 20) & v >= -(1 << 20));
         public bool Equals (int2 a, int2 b) => math.all(a == b);
         public float Distance (int2 a, int2 b) => math.distance(a, b);

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -360,7 +360,7 @@ namespace andywiecko.BurstTriangulator
             public NativeReference<Status> Status;
         }
         [BurstCompile]
-        private struct TriangulationJob<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : ICoordinateUtils<TCoord, TLengthSq>, new()
+        private struct TriangulationJob<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : unmanaged, ICoordinateUtils<TCoord, TLengthSq>
         {
             public Preprocessor preprocessor;
             public bool validateInput;
@@ -545,7 +545,7 @@ namespace andywiecko.BurstTriangulator
             }
         }
 
-        private struct DelaunayTriangulator<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : ICoordinateUtils<TCoord, TLengthSq>, new()
+        private struct DelaunayTriangulator<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : unmanaged, ICoordinateUtils<TCoord, TLengthSq>
         {
             private struct DistComparer : IComparer<int>
             {
@@ -906,7 +906,7 @@ namespace andywiecko.BurstTriangulator
             }
         }
 
-        private struct ValidateInputConstraintEdges<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : ICoordinateUtils<TCoord, TLengthSq>, new()
+        private struct ValidateInputConstraintEdges<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : unmanaged, ICoordinateUtils<TCoord, TLengthSq>
         {
             [ReadOnly]
             public NativeArray<int> constraints;
@@ -1035,7 +1035,7 @@ namespace andywiecko.BurstTriangulator
             }
         }
 
-        private struct ConstrainEdgesJob<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : ICoordinateUtils<TCoord, TLengthSq>, new()
+        private struct ConstrainEdgesJob<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : unmanaged, ICoordinateUtils<TCoord, TLengthSq>
         {
             public NativeReference<Status> status;
             [ReadOnly]
@@ -1395,7 +1395,7 @@ namespace andywiecko.BurstTriangulator
             }
         }
 
-        private struct RefineMeshJob<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : ICoordinateUtils<TCoord, TLengthSq>, new()
+        private struct RefineMeshJob<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : unmanaged, ICoordinateUtils<TCoord, TLengthSq>
         {
             public TLengthSq maximumArea2;
             public float minimumAngle;
@@ -2039,7 +2039,7 @@ namespace andywiecko.BurstTriangulator
             }
         }
 
-        private struct SeedPlanter<TCoord, TLengthSq, TUtils> where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : ICoordinateUtils<TCoord, TLengthSq>, new()
+        private struct SeedPlanter<TCoord, TLengthSq, TUtils> where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : unmanaged, ICoordinateUtils<TCoord, TLengthSq>
         {
             private NativeReference<Status>.ReadOnly status;
             private NativeList<int> triangles;

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -343,20 +343,41 @@ namespace andywiecko.BurstTriangulator
 
         #region Jobs
 
-        public struct InputData<TCoord> where TCoord : unmanaged
+        public struct InputData<TCoord> : IDisposable where TCoord : unmanaged
         {
             public NativeArray<TCoord> Positions;
             [NativeDisableContainerSafetyRestriction]
             public NativeArray<int> ConstraintEdges;
             [NativeDisableContainerSafetyRestriction]
             public NativeArray<TCoord> HoleSeeds;
+
+            public void Dispose()
+            {
+                Positions.Dispose();
+                ConstraintEdges.Dispose();
+                HoleSeeds.Dispose();
+            }
         }
 
-        public struct OutputData<TCoord> where TCoord : unmanaged {
+        public struct OutputData<TCoord> : IDisposable where TCoord : unmanaged {
             [NativeDisableContainerSafetyRestriction]
             public NativeList<TCoord> Positions;
             public NativeList<int> Triangles;
             public NativeReference<Status> Status;
+
+            public OutputData(Allocator allocator)
+            {
+                Positions = new NativeList<TCoord>(allocator);
+                Triangles = new NativeList<int>(allocator);
+                Status = new NativeReference<Status>(allocator);
+            }
+
+            public void Dispose ()
+            {
+                Positions.Dispose();
+                Triangles.Dispose();
+                Status.Dispose();
+            }
         }
         [BurstCompile]
         private struct TriangulationJob<TCoord, TLengthSq, TUtils> : IJob where TCoord : unmanaged where TLengthSq : unmanaged, IComparable<TLengthSq> where TUtils : unmanaged, ICoordinateUtils<TCoord, TLengthSq>

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -317,7 +317,7 @@ namespace andywiecko.BurstTriangulator
                 sloanMaxIters = settings.SloanMaxIters,
                 verbose = settings.Verbose,
                 concentricShellsParameter = settings.ConcentricShellsParameter,
-                refinementThresholdArea = (ulong)settings.RefinementThresholds.Area,
+                refinementThresholdArea = settings.RefinementThresholds.Area,
                 refinementThresholdAngle = settings.RefinementThresholds.Angle,
                 input = input,
                 output = output

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -60,6 +60,13 @@ namespace andywiecko.BurstTriangulator
                 for (int i = 0; i < points.Length; i++) points[i] = Transform(points[i]);
             }
 
+            public override string ToString() => $"{nameof(AffineTransform2D)}(translation={translation}, rotScale={rotScale})";
+
+            public static bool operator ==(AffineTransform2D lhs, AffineTransform2D rhs) => lhs.Equals(rhs);
+            public static bool operator !=(AffineTransform2D lhs, AffineTransform2D rhs) => !lhs.Equals(rhs);
+            public override bool Equals(object obj) => obj is AffineTransform2D other && Equals(other);
+            public bool Equals(AffineTransform2D other) => rotScale.Equals(other.rotScale) && translation.Equals(other.translation);
+
             public void Transform([NoAlias] NativeArray<float2> points, [NoAlias] NativeArray<float2> outPoints)
             {
                 if (points.Length != outPoints.Length) throw new ArgumentException("Input and output arrays must have the same length!");
@@ -78,8 +85,6 @@ namespace andywiecko.BurstTriangulator
                 var invRotScale = math.inverse(rotScale);
                 for (int i = 0; i < points.Length; i++) outPoints[i] = math.mul(invRotScale, points[i]) - translation;
             }
-
-            public override string ToString() => $"{nameof(AffineTransform2D)}(translation={translation}, rotScale={rotScale})";
         }
         private readonly struct Circle
         {

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -64,6 +64,7 @@ namespace andywiecko.BurstTriangulator
 
             public static bool operator ==(AffineTransform2D lhs, AffineTransform2D rhs) => lhs.Equals(rhs);
             public static bool operator !=(AffineTransform2D lhs, AffineTransform2D rhs) => !lhs.Equals(rhs);
+            public override int GetHashCode() => (rotScale.GetHashCode() * 397) ^ translation.GetHashCode();
             public override bool Equals(object obj) => obj is AffineTransform2D other && Equals(other);
             public bool Equals(AffineTransform2D other) => rotScale.Equals(other.rotScale) && translation.Equals(other.translation);
 


### PR DESCRIPTION
- **feat: add equals operator for AffineTransform2D**
- **feat: add support for integer coordinates**

Performance for floating point triangulation seems unchanged, or possibly a tiny bit slower (left side is new version, right side is old version before PR).
I have run each benchmark test many times and plotted the results in a box plot. The box represents the upper/lower quartiles.
The plot is divided into a grid based on the test parameters.

![Triangulation_Delaunay_Delaunay](https://github.com/andywiecko/BurstTriangulator/assets/1144597/321cd25c-0bdd-41f0-97c1-1aaa7f7b4e9d)

![Triangulation_RefineMesh_RefineMesh](https://github.com/andywiecko/BurstTriangulator/assets/1144597/8f56c9f9-0937-4073-9d68-03624bfce5ad)

![Triangulation_Constrained_Constrained](https://github.com/andywiecko/BurstTriangulator/assets/1144597/aab214bc-67e3-4c44-aa63-0587148a94f6)

Performance with integer coordinates seems to be very close to floating point coordinates (compare with previous screenshot). Indicating that this is not something that matters much for the algorithm:

![Triangulation_Constrained int2_Constrained int2](https://github.com/andywiecko/BurstTriangulator/assets/1144597/1539e60f-b374-4ffa-9aa4-a4c22eca6eb9)


Preprocessing is not supported for integer coordinates. It shouldn't be needed anyway. Though, I guess moving everything to the origin could make the safety margins higher.

It's kinda ugly how a lot of static calls had to be replaced by `new CoordinateUtils().MyStaticCall(...)`, but I can't think of a better way. Burst optimizes the constructor away, of course, so it has equivalent performance to a static call.