### PR TITLE
Add ability to ignore some positions in the triangulation

### DIFF
--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -231,7 +231,6 @@ namespace andywiecko.BurstTriangulator
         public class InputData
         {
             public NativeArray<float2> Positions { get; set; }
-            
             public NativeArray<bool> IgnorePositions { get; set; }
             public NativeArray<int> ConstraintEdges { get; set; }
             public NativeArray<float2> HoleSeeds { get; set; }


### PR DESCRIPTION
As per [our discussion](https://github.com/jimmycushnie/BurstTriangulator/commit/19e765a7d368a252ef81edb64da6adae5200ffdf#commitcomment-141764859) on my fork, I am opening a PR for this feature.

When creating a new triangulation job, you can now optionally pass a `NativeArray<bool>` called `IgnorePositions`. This array should be the same length as the Positions array. Any indices in `Positions` that are true in IgnorePositions will not be used in the triangulation.

I'm using this to regenerate the triangles of a mesh using a subset of its vertices without needing to update the mesh's vertices.

Things to address before merging:

- [ ] Code review
- [ ] Benchmark to make sure there's no significant performance regression
- [ ] Input validation: if `IgnorePositions` is created, should we validate that it's the same length as `Positions`?
- [ ] Add documentation

Thank you @andywiecko for making this excellent library, for encouraging me to contribute, and for your generous help with this code.