### PR TITLE
feat: make halfedges public

### DIFF
--- a/Documentation~/images/manual-halfedges.svg
+++ b/Documentation~/images/manual-halfedges.svg
@@ -1,0 +1,437 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="56.747444mm"
+   height="43.847866mm"
+   viewBox="0 0 56.747444 43.847866"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   sodipodi:docname="manual-halfedges.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.5091049"
+     inkscape:cx="193.16085"
+     inkscape:cy="134.51682"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g2559-6" />
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="TriangleStart"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-5"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-4" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-6"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-8" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-3"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-0"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-2" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-2"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-3" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-4"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-0" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-69"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-46" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-52"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-02" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-61"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-97" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-8"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-30" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleStart-1"
+       refX="2.5"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleStart"
+       markerWidth="2.25"
+       markerHeight="3"
+       viewBox="0 0 5.3244081 6.1553851"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid"
+       markerUnits="userSpaceOnUse">
+      <path
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.5pt"
+         d="M 2.885,0 -1.44,2.5 v -5 z"
+         id="path135-1" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Warstwa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-32.946083,-43.991537)">
+    <g
+       id="g2559-4"
+       transform="translate(33.659003,-9.1913293)">
+      <text
+         xml:space="preserve"
+         style="font-size:4.23333px;font-family:'Lucida Sans Unicode';-inkscape-font-specification:'Lucida Sans Unicode';fill:none;stroke:#000000;stroke-width:0.1;stroke-dasharray:none;stroke-opacity:1"
+         x="50.566128"
+         y="84.85714"
+         id="text953-5"><tspan
+           sodipodi:role="line"
+           id="tspan951-5"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:Consolas;-inkscape-font-specification:Consolas;fill:#000000;fill-opacity:1;stroke-width:0.1;stroke-dasharray:none"
+           x="50.566128"
+           y="84.85714">1</tspan></text>
+      <g
+         id="g2559-3"
+         transform="translate(-8.1525969,-26.035714)">
+        <text
+           xml:space="preserve"
+           style="font-size:4.23333px;font-family:'Lucida Sans Unicode';-inkscape-font-specification:'Lucida Sans Unicode';fill:none;stroke:#000000;stroke-width:0.1;stroke-dasharray:none;stroke-opacity:1"
+           x="50.566128"
+           y="84.85714"
+           id="text953-51"><tspan
+             sodipodi:role="line"
+             id="tspan951-9"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:Consolas;-inkscape-font-specification:Consolas;fill:#000000;fill-opacity:1;stroke-width:0.1;stroke-dasharray:none"
+             x="50.566128"
+             y="84.85714">2</tspan></text>
+        <g
+           id="g2559-6"
+           transform="translate(-15.954545,15.340909)">
+          <circle
+             style="fill:none;stroke:#000000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+             id="path184-4"
+             cx="51.724113"
+             cy="83.528992"
+             r="4.060411" />
+          <text
+             xml:space="preserve"
+             style="font-size:4.23333px;font-family:'Lucida Sans Unicode';-inkscape-font-specification:'Lucida Sans Unicode';fill:none;stroke:#000000;stroke-width:0.1;stroke-dasharray:none;stroke-opacity:1"
+             x="50.566128"
+             y="84.85714"
+             id="text953-4"><tspan
+               sodipodi:role="line"
+               id="tspan951-98"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:Consolas;-inkscape-font-specification:Consolas;fill:#000000;fill-opacity:1;stroke-width:0.1;stroke-dasharray:none"
+               x="50.566128"
+               y="84.85714">4</tspan></text>
+          <path
+             style="fill:#666666;fill-opacity:1;stroke:#ff000f;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart)"
+             d="M 72.017943,96.020873 46.815022,102.63938"
+             id="path2736"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#666666;fill-opacity:1;stroke:#ff000f;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-5)"
+             d="M 70.116227,71.528247 75.22477,89.614281"
+             id="path2736-5"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#666666;fill-opacity:1;stroke:#ff000f;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-6)"
+             d="M 31.932461,68.862822 62.976446,67.940875"
+             id="path2736-9"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#666666;fill-opacity:1;stroke:#ff000f;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-3)"
+             d="M 39.30887,100.35203 28.452256,74.26899"
+             id="path2736-7"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-0)"
+             d="M 43.895881,99.546205 50.973278,88.188911"
+             id="path2736-0"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-2)"
+             d="M 55.435572,85.113091 71.444129,92.40479"
+             id="path2736-01"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-4)"
+             d="M 73.060592,91.085029 56.419575,83.392372"
+             id="path2736-010"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-69)"
+             d="m 55.391741,81.869585 9.549716,-9.812703"
+             id="path2736-2"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-52)"
+             d="m 64.157975,70.363903 -9.744216,9.262074"
+             id="path2736-4"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-61)"
+             d="M 49.211546,80.291662 31.942067,71.744585"
+             id="path2736-8"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-8)"
+             d="m 30.24957,72.909948 17.006495,9.116884"
+             id="path2736-6"
+             sodipodi:nodetypes="cc" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.499999;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleStart-1)"
+             d="M 49.562195,87.129325 42.045979,98.753631"
+             id="path2736-77"
+             sodipodi:nodetypes="cc" />
+          <g
+             id="g2559-0"
+             transform="translate(-24.019481,-13.938312)">
+            <circle
+               style="fill:none;stroke:#000000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+               id="path184-5"
+               cx="51.724113"
+               cy="83.528992"
+               r="4.060411" />
+            <text
+               xml:space="preserve"
+               style="font-size:4.23333px;font-family:'Lucida Sans Unicode';-inkscape-font-specification:'Lucida Sans Unicode';fill:none;stroke:#000000;stroke-width:0.1;stroke-dasharray:none;stroke-opacity:1"
+               x="50.566128"
+               y="84.85714"
+               id="text953-7"><tspan
+                 sodipodi:role="line"
+                 id="tspan951-0"
+                 style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:Consolas;-inkscape-font-specification:Consolas;fill:#000000;fill-opacity:1;stroke-width:0.1;stroke-dasharray:none"
+                 x="50.566128"
+                 y="84.85714">3</tspan></text>
+          </g>
+        </g>
+        <circle
+           style="fill:none;stroke:#000000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+           id="path184-7"
+           cx="51.724113"
+           cy="83.528992"
+           r="4.060411" />
+      </g>
+      <circle
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+         id="path184-1"
+         cx="51.724113"
+         cy="83.528992"
+         r="4.060411" />
+    </g>
+    <g
+       id="g2559">
+      <circle
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-dasharray:none;stroke-opacity:1"
+         id="path184"
+         cx="51.724113"
+         cy="83.528992"
+         r="4.060411" />
+      <text
+         xml:space="preserve"
+         style="font-size:4.23333px;font-family:'Lucida Sans Unicode';-inkscape-font-specification:'Lucida Sans Unicode';fill:none;stroke:#000000;stroke-width:0.1;stroke-dasharray:none;stroke-opacity:1"
+         x="50.566128"
+         y="84.85714"
+         id="text953"><tspan
+           sodipodi:role="line"
+           id="tspan951"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:Consolas;-inkscape-font-specification:Consolas;fill:#000000;fill-opacity:1;stroke-width:0.1;stroke-dasharray:none"
+           x="50.566128"
+           y="84.85714">0</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/Documentation~/manual/advanced/output-halfedges.md
+++ b/Documentation~/manual/advanced/output-halfedges.md
@@ -1,0 +1,37 @@
+# Halfedges
+
+```csharp
+using var triangulator = new Triangulator(Allocator.Persistent){ Input = { ... } };
+triangulator.Run();
+var halfedges = triangulator.Output.Halfedges;
+```
+
+For each successful triangulation (with any settings) except triangles and positions, one can get [`Output.Halfedges`][halfedges].
+Halfedges are a data structure that describes neighboring triangles.
+All triangles in the generated mesh are clockwise.
+For example, consider triangle $(a, b, c)$ (at indexes: $i, i+1, i+2$ in [`Output.Triangles`][triangles]), which is made of 3 halfedges $(a, b)$, $(b, c)$, $(c, a)$.
+A halfedge is a directed edge, i.e., $(i, j) \neq (j, i)$.
+In the halfedges buffer, one can find the $\mathtt{id}$ of the opposite halfedge, if it exists.
+In the case when the opposite halfedge is not present in a mesh, then `Output.Triangles[id] = -1`.
+
+Consider the following example where $\triangle$ stands for triangles and $\mathtt{he}$ for the halfedges buffer.
+
+<br>
+<p align="center"><img src="../../images/manual-halfedges.svg" width="200"/></p>
+<br>
+
+$$
+\begin{array} {c|ccc|ccc|ccc|ccc}
+    \mathtt{id} & 0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 & 10 & 11\\\hline
+    \triangle & 0 & 4 & 1 & 1 & 4 & 2 & 2 & 4 & 3 & 3 & 4 & 0\\
+    \mathtt{he} & 10 & 3 & -1 & 1 & 6 & -1 & 4 & 9 & -1 & 7 & 0 & -1
+\end{array}
+$$
+
+---
+
+For more details follow the delaunator **[guide]**.
+
+[triangles]: xref:andywiecko.BurstTriangulator.Triangulator.OutputData.Triangles
+[halfedges]: xref:andywiecko.BurstTriangulator.Triangulator.OutputData.Halfedges
+[guide]: https://mapbox.github.io/delaunator/

--- a/Documentation~/manual/toc.yml
+++ b/Documentation~/manual/toc.yml
@@ -29,6 +29,8 @@ items:
     href: advanced/input-jobs.md
   - name: Preprocessor
     href: advanced/preprocessor.md
+  - name: Halfedges
+    href: advanced/output-halfedges.md
 
 - name: Benchmark
   href: benchmark.md


### PR DESCRIPTION
This commit makes `Halfedges` available as additional output data. This mapping can be used by advanced users. My main motivation is to prepare package addon with path-finding utilities for tri-meshes.