### PR TITLE
feat: introduce generics for coordinates

### DIFF
--- a/Tests/TriangulatorEditorTests.cs
+++ b/Tests/TriangulatorEditorTests.cs
@@ -580,14 +580,14 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                 TestName = "Test case 1 (square)",
                 ExpectedResult = new []
                 {
-                    (5, 1, 4),
-                    (6, 4, 1),
-                    (7, 3, 4),
+                    (6, 4, 5),
+                    (6, 5, 1),
                     (8, 2, 5),
                     (8, 5, 4),
                     (9, 4, 6),
                     (9, 7, 4),
-                    (10, 4, 3),
+                    (10, 4, 7),
+                    (10, 7, 3),
                     (10, 8, 4),
                     (11, 0, 9),
                     (11, 9, 6),


### PR DESCRIPTION
- This commit introduces generics to `TriangulationJob<...>`, enabling  the implementation of `Triangulator<T>` in the future.
- It adds an interface for utilities `IUtils<T, T2>` and an interface for transformations `ITransformation<TSelf, T, T2>` with default implementations for single precision `float`s: `FloatUtils` and `AffineTransform32`, respectively.
- Additionally, the `Circle` struct is hidden in the refinement step and other utilities are based on `Circle.RadiusSq` instead of `Circle.Radius`, which should result in better float approximation.

---

For the next commits, the plan is to introduce `DoubleUtils`, `AffineTransform64`, and finally `Triangulator<T>`.