### PR TITLE
feat: support for integer coordinates

### DIFF
--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2706,12 +2706,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
     internal interface IUtils<T, T2, TBig> where T : unmanaged where T2 : unmanaged where TBig : unmanaged
     {
         /// <summary>
-        /// Converts a value to type T.
-        ///
-        /// Warning: This may cause loss of precision for very large integers.
-        /// </summary>
-        T Const(int v);
-        /// <summary>
         /// Converts a value to type TBig.
         ///
         /// Warning: This may cause loss of precision, and is only safe for (not huge) integer constants.
@@ -2723,10 +2717,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         T2 MaxValue2();
         TBig MaxDistSq();
         T2 MinValue2();
-        T2 NewT2(T x, T y);
         T X(T2 v);
         T Y(T2 v);
-        T Zero();
         TBig ZeroSq();
         bool SupportsMeshRefinement { get; }
 
@@ -2787,7 +2779,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
     internal readonly struct FloatUtils : IUtils<float, float2, float>
     {
-        public readonly float Const(int v) => v;
         public readonly float ConstDistanceSq(float v) => v;
         public readonly float EPSILON() => math.EPSILON;
         public readonly float EPSILON_TBIG() => EPSILON();
@@ -2795,10 +2786,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly float2 MaxValue2() => float.MaxValue;
         public readonly float MaxDistSq() => float.MaxValue;
         public readonly float2 MinValue2() => float.MinValue;
-        public readonly float2 NewT2(float x, float y) => math.float2(x, y);
         public readonly float X(float2 a) => a.x;
         public readonly float Y(float2 a) => a.y;
-        public readonly float Zero() => 0;
         public readonly float ZeroSq() => 0;
         public readonly bool SupportsMeshRefinement => true;
 
@@ -2907,7 +2896,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
     internal readonly struct DoubleUtils : IUtils<double, double2, double>
     {
-        public readonly double Const(int v) => v;
         public readonly double ConstDistanceSq(float v) => v;
         public readonly double EPSILON() => math.EPSILON_DBL;
         public readonly double EPSILON_TBIG() => EPSILON();
@@ -2915,10 +2903,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly double2 MaxValue2() => double.MaxValue;
         public readonly double MaxDistSq() => double.MaxValue;
         public readonly double2 MinValue2() => double.MinValue;
-        public readonly double2 NewT2(double x, double y) => math.double2(x, y);
         public readonly double X(double2 a) => a.x;
         public readonly double Y(double2 a) => a.y;
-        public readonly double Zero() => 0;
         public readonly double ZeroSq() => 0;
         public readonly bool SupportsMeshRefinement => true;
 
@@ -3027,7 +3013,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
     internal readonly struct IntUtils : IUtils<int, int2, long>
     {
-        public readonly int Const(int v) => v;
         public readonly long ConstDistanceSq(float v) => (long)v;
         public readonly int EPSILON() => 0;
         public readonly long EPSILON_TBIG() => 0;
@@ -3035,10 +3020,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly int2 MaxValue2() => int.MaxValue;
         public readonly long MaxDistSq() => long.MaxValue;
         public readonly int2 MinValue2() => int.MinValue;
-        public readonly int2 NewT2(int x, int y) => math.int2(x, y);
         public readonly int X(int2 a) => a.x;
         public readonly int Y(int2 a) => a.y;
-        public readonly int Zero() => 0;
         public readonly long ZeroSq() => 0;
         public readonly bool SupportsMeshRefinement => false;
 

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -361,6 +361,11 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public static void PlantHoleSeeds(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
         public static void RefineMesh(this UnsafeTriangulator<double2> @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) =>
             new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+
+        public static void Triangulate(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, float, long, TranslationInt32, IntUtils>().Triangulate(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, float, long, TranslationInt32, IntUtils>().PlantHoleSeeds(input, output, args, allocator);
+        public static void RefineMesh(this UnsafeTriangulator<int2> @this, OutputData<int2> output, Allocator allocator, long areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) =>
+            new UnsafeTriangulator<int, int2, float, long, TranslationInt32, IntUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
     }
 
     [BurstCompile]

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -840,7 +840,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 }
 
                 // Swap the order of the vertices if the triangle is not oriented in the right direction
-                if (utils.less(Orient2dFast(p0, p1, p2), utils.ZeroSq()))
+                if (utils.less(Orient2dFast(p0, p1, p2), utils.ZeroTBig()))
                 {
                     (i1, i2) = (i2, i1);
                     (p1, p2) = (p2, p1);
@@ -892,7 +892,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     var e = start;
                     var q = hullNext[e];
 
-                    while (!utils.less(Orient2dFast(p, positions[e], positions[q]), utils.ZeroSq()))
+                    while (!utils.less(Orient2dFast(p, positions[e], positions[q]), utils.ZeroTBig()))
                     {
                         e = q;
                         if (e == start)
@@ -918,7 +918,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     q = hullNext[next];
 
                     // Walk forward through the hull, adding more triangles and flipping recursively
-                    while (utils.less(Orient2dFast(p, positions[next], positions[q]), utils.ZeroSq()))
+                    while (utils.less(Orient2dFast(p, positions[next], positions[q]), utils.ZeroTBig()))
                     {
                         t = AddTriangle(next, i, q, hullTri[i], -1, hullTri[next]);
                         hullTri[i] = Legalize(t + 2);
@@ -933,7 +933,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     {
                         q = hullPrev[e];
 
-                        while (utils.less(Orient2dFast(p, positions[q], positions[e]), utils.ZeroSq()))
+                        while (utils.less(Orient2dFast(p, positions[q], positions[e]), utils.ZeroTBig()))
                         {
                             t = AddTriangle(q, i, e, -1, hullTri[e], hullTri[q]);
                             Legalize(t + 2);
@@ -1769,7 +1769,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private readonly int initialPointsCount;
 
             public RefineMeshStep(OutputData<T2> output, Args args, TTransform lt) : this(output,
-                area2Threshold: utils.mul(utils.ConstDistanceSq(2), lt.TransformArea(utils.ConstDistanceSq(args.RefinementThresholdArea))),
+                area2Threshold: utils.mul(utils.ConstTBig(2), lt.TransformArea(utils.ConstTBig(args.RefinementThresholdArea))),
                 angleThreshold: args.RefinementThresholdAngle,
                 shells: args.ConcentricShellsParameter)
             { }
@@ -1887,7 +1887,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 var p1 = outputPositions[triangles[he1]];
                 var p2 = outputPositions[triangles[he2]];
 
-                return utils.le(utils.dot(utils.diff(p0, p2), utils.diff(p1, p2)), utils.ZeroSq());
+                return utils.le(utils.dot(utils.diff(p0, p2), utils.diff(p1, p2)), utils.ZeroTBig());
             }
 
             private void SplitEdge(int he, NativeList<int> heQueue, NativeList<int> tQueue)
@@ -2013,7 +2013,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     if (halfedges[he] == -1 || i < j)
                     {
                         var (p0, p1) = (outputPositions[i], outputPositions[j]);
-                        if (utils.le(utils.dot(utils.diff(p0, c.Center), utils.diff(p1, c.Center)), utils.ZeroSq()))
+                        if (utils.le(utils.dot(utils.diff(p0, c.Center), utils.diff(p1, c.Center)), utils.ZeroTBig()))
                         {
                             edges.Add(he);
                         }
@@ -2710,7 +2710,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         ///
         /// Warning: This may cause loss of precision, and is only safe for (not huge) integer constants.
         /// </summary>
-        TBig ConstDistanceSq(float v);
+        TBig ConstTBig(float v);
         T EPSILON();
         TBig EPSILON_TBIG();
         T MaxValue();
@@ -2719,7 +2719,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         T2 MinValue2();
         T X(T2 v);
         T Y(T2 v);
-        TBig ZeroSq();
+        TBig ZeroTBig();
         bool SupportsMeshRefinement { get; }
 
         bool PointInsideTriangle(T2 p, T2 a, T2 b, T2 c);
@@ -2779,7 +2779,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
     internal readonly struct FloatUtils : IUtils<float, float2, float>
     {
-        public readonly float ConstDistanceSq(float v) => v;
+        public readonly float ConstTBig(float v) => v;
         public readonly float EPSILON() => math.EPSILON;
         public readonly float EPSILON_TBIG() => EPSILON();
         public readonly float MaxValue() => float.MaxValue;
@@ -2788,7 +2788,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly float2 MinValue2() => float.MinValue;
         public readonly float X(float2 a) => a.x;
         public readonly float Y(float2 a) => a.y;
-        public readonly float ZeroSq() => 0;
+        public readonly float ZeroTBig() => 0;
         public readonly bool SupportsMeshRefinement => true;
 
         static float cross(float2 a, float2 b) => a.x * b.y - a.y * b.x;
@@ -2896,7 +2896,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
     internal readonly struct DoubleUtils : IUtils<double, double2, double>
     {
-        public readonly double ConstDistanceSq(float v) => v;
+        public readonly double ConstTBig(float v) => v;
         public readonly double EPSILON() => math.EPSILON_DBL;
         public readonly double EPSILON_TBIG() => EPSILON();
         public readonly double MaxValue() => double.MaxValue;
@@ -2905,7 +2905,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly double2 MinValue2() => double.MinValue;
         public readonly double X(double2 a) => a.x;
         public readonly double Y(double2 a) => a.y;
-        public readonly double ZeroSq() => 0;
+        public readonly double ZeroTBig() => 0;
         public readonly bool SupportsMeshRefinement => true;
 
         static double cross(double2 a, double2 b) => a.x * b.y - a.y * b.x;
@@ -3013,7 +3013,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
     internal readonly struct IntUtils : IUtils<int, int2, long>
     {
-        public readonly long ConstDistanceSq(float v) => (long)v;
+        public readonly long ConstTBig(float v) => (long)v;
         public readonly int EPSILON() => 0;
         public readonly long EPSILON_TBIG() => 0;
         public readonly int MaxValue() => int.MaxValue;
@@ -3022,7 +3022,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly int2 MinValue2() => int.MinValue;
         public readonly int X(int2 a) => a.x;
         public readonly int Y(int2 a) => a.y;
-        public readonly long ZeroSq() => 0;
+        public readonly long ZeroTBig() => 0;
         public readonly bool SupportsMeshRefinement => false;
 
         public long cross(int2 a, int2 b) => (long)a.x * (long)b.y - (long)a.y * (long)b.x;

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -3081,27 +3081,11 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         }
 
         public readonly int2 PickPointOnConcentricShell(float D, int2 e1, int2 e2, bool initial) {
-            var d = math.sqrt((double)this.distancesq(e1, e2));
-            var k = (int)math.round(math.log2(0.5 * d / D));
-            var alpha = D / d * (1 << k);
-            alpha = initial ? alpha : 1 - alpha;
-            // Lerp
-            return e1 + (int2)math.round((double2)(e2 - e1) * alpha);
+            throw new NotImplementedException("PickPointOnConcentricShell is not implemented for integer coordinates.");
         }
 
         public readonly bool SmallestInnerAngleIsBelowThreshold(int2 a, int2 b, int2 c, float cosAngle) {
-            var ab = b - a;
-            var bc = c - b;
-            var ca = a - c;
-            var lab = dot(ab, ab);
-            var lbc = dot(bc, bc);
-            var lca = dot(ca, ca);
-            // Necessary to handle degenerate triangles, for which the smallest inner angle should be zero.
-            if (lab == 0 || lbc == 0 || lca == 0) return cosAngle < 1;
-            if ((double)dot(ab, -ca) > cosAngle * math.sqrt((double)lab * (double)lca)) return true;
-            if ((double)dot(bc, -ab) > cosAngle * math.sqrt((double)lbc * (double)lab)) return true;
-            if ((double)dot(ca, -bc) > cosAngle * math.sqrt((double)lca * (double)lbc)) return true;
-            return false;
+            throw new NotImplementedException("SmallestInnerAngleIsBelowThreshold is not implemented for integer coordinates.");
         }
 
         public readonly int abs(int v) => math.abs(v);

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -364,8 +364,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public static void Triangulate(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, float, long, TranslationInt32, IntUtils>().Triangulate(input, output, args, allocator);
         public static void PlantHoleSeeds(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, float, long, TranslationInt32, IntUtils>().PlantHoleSeeds(input, output, args, allocator);
-        public static void RefineMesh(this UnsafeTriangulator<int2> @this, OutputData<int2> output, Allocator allocator, long areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<int, int2, float, long, TranslationInt32, IntUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
     }
 
     [BurstCompile]

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -3081,10 +3081,14 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         }
 
         public readonly int2 PickPointOnConcentricShell(float D, int2 e1, int2 e2, bool initial) {
+            // Implementation has been removed because it's not used at the moment.
+            // This commit has the implemenation, if it's needed in the future: ad22afe
             throw new NotImplementedException("PickPointOnConcentricShell is not implemented for integer coordinates.");
         }
 
         public readonly bool SmallestInnerAngleIsBelowThreshold(int2 a, int2 b, int2 c, float cosAngle) {
+            // Implementation has been removed because it's not used at the moment.
+            // This commit has the implemenation, if it's needed in the future: ad22afe
             throw new NotImplementedException("SmallestInnerAngleIsBelowThreshold is not implemented for integer coordinates.");
         }
 

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -1815,9 +1815,11 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     return;
                 }
 
-                // We cannot do a typeof check here because it prevents burst compilation.
-                // But we know that IntUtils is the only one for which EPSILON==0.
-                if (utils.eq(utils.EPSILON(), utils.Zero())) throw new NotSupportedException("Mesh refinement is not supported for integer types.");
+                if (!utils.SupportsMeshRefinement) {
+                    Debug.LogError("Mesh refinement is not supported for this coordinate type.");
+                    status.Value |= Status.ERR;
+                    return;
+                }
 
                 if (constrainBoundary)
                 {
@@ -2758,6 +2760,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         T Y(T2 v);
         T Zero();
         TSquare ZeroSq();
+        bool SupportsMeshRefinement { get; }
 #pragma warning disable IDE1006
         T abs(T v);
         TSquare abs(TSquare v);
@@ -2818,6 +2821,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly float Y(float2 a) => a.y;
         public readonly float Zero() => 0;
         public readonly float ZeroSq() => 0;
+        public readonly bool SupportsMeshRefinement => true;
         public readonly float abs(float v) => math.abs(v);
         public readonly float add(float a, float b) => a + b;
         public readonly float alpha(float D, float dSquare, bool initial)
@@ -2924,6 +2928,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly double Y(double2 a) => a.y;
         public readonly double Zero() => 0;
         public readonly double ZeroSq() => 0;
+        public readonly bool SupportsMeshRefinement => true;
         public readonly double abs(double v) => math.abs(v);
         public readonly double add(double a, double b) => a + b;
         public readonly double alpha(double D, double dSquare, bool initial)
@@ -3030,6 +3035,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly int Y(int2 a) => a.y;
         public readonly int Zero() => 0;
         public readonly long ZeroSq() => 0;
+        public readonly bool SupportsMeshRefinement => false;
         public readonly int abs(int v) => math.abs(v);
         public readonly long abs(long v) => math.abs(v);
         public readonly int add(int a, int b) => a + b;

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -1307,13 +1307,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             private void CollectIntersections(int2 edge)
             {
-                // Collect all intersections between existing edges, and the given constrained edge.
-                // We will later get rid of all of these intersections, so that the constrained edge
-                // can be inserted.
-                //
-                // We start at one side of the edge (ci=edge.x), then we go through all existing
-                // halfedges that connect to that vertex. We check if the triangle formed
-                //
                 // 1. Check if h1 is cj
                 // 2. Check if h1-h2 intersects with ci-cj
                 // 3. After each iteration: h0 <- h0'

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -1808,7 +1808,9 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     return;
                 }
 
-                if (typeof(T) == typeof(int)) throw new NotSupportedException("Mesh refinement is not supported for integer types.");
+                // We cannot do a typeof check here because it prevents burst compilation.
+                // But we know that IntUtils is the only one for which EPSILON==0.
+                if (utils.eq(utils.EPSILON(), utils.Zero())) throw new NotSupportedException("Mesh refinement is not supported for integer types.");
 
                 if (constrainBoundary)
                 {

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -1312,6 +1312,13 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             private void CollectIntersections(int2 edge)
             {
+                // Collect all intersections between existing edges, and the given constrained edge.
+                // We will later get rid of all of these intersections, so that the constrained edge
+                // can be inserted.
+                //
+                // We start at one side of the edge (ci=edge.x), then we go through all existing
+                // halfedges that connect to that vertex. We check if the triangle formed
+                //
                 // 1. Check if h1 is cj
                 // 2. Check if h1-h2 intersects with ci-cj
                 // 3. After each iteration: h0 <- h0'
@@ -2448,6 +2455,13 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             utils.mul(utils.diff(utils.Y(c), utils.Y(a)), utils.diff(utils.X(b), utils.X(a))),
             utils.mul(utils.diff(utils.Y(b), utils.Y(a)), utils.diff(utils.X(c), utils.X(a)))
         );
+
+        /// <summary>
+        /// True if the edge (a0, a1) intersects the edge (b0, b1).
+        ///
+        /// Colinear edges will not be considered as intersecting.
+        /// Intersections only at the endpoints will not be considered as intersecting.
+        /// </summary>
         internal static bool EdgeEdgeIntersection(T2 a0, T2 a1, T2 b0, T2 b1) => ccw(a0, a1, b0) != ccw(a0, a1, b1) && ccw(b0, b1, a0) != ccw(b0, b1, a1);
         private static int NextHalfedge(int he) => he % 3 == 2 ? he - 2 : he + 1;
         private static bool InCircle(T2 a, T2 b, T2 c, T2 p) => utils.inCircle(a, b, c, p);

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2711,7 +2711,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// Warning: This may cause loss of precision, and is only safe for (not huge) integer constants.
         /// </summary>
         TBig ConstTBig(float v);
-        T EPSILON();
         TBig EPSILON_TBIG();
         T MaxValue();
         T2 MaxValue2();
@@ -2756,32 +2755,26 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         TBig dot(T2 a, T2 b);
         bool eq(T v, T w);
         bool2 eq(T2 v, T2 w);
-        bool ge(T a, T b);
         bool2 ge(T2 a, T2 b);
         bool greater(T a, T b);
         bool greater(TBig a, TBig b);
         int hashkey(T2 p, T2 c, int hashSize);
         bool2 isfinite(T2 v);
-        bool le(T a, T b);
         bool2 le(T2 a, T2 b);
         bool le(TBig a, TBig b);
         bool less(T a, T b);
         bool less(TBig a, TBig b);
-        T max(T v, T w);
         T2 max(T2 v, T2 w);
         T2 min(T2 v, T2 w);
         TBig mul(T a, T b);
         TBig mul(TBig a, TBig b);
-        T neg(T v);
-        T2 neg(T2 v);
 #pragma warning restore IDE1006
     }
 
     internal readonly struct FloatUtils : IUtils<float, float2, float>
     {
         public readonly float ConstTBig(float v) => v;
-        public readonly float EPSILON() => math.EPSILON;
-        public readonly float EPSILON_TBIG() => EPSILON();
+        public readonly float EPSILON_TBIG() => math.EPSILON;
         public readonly float MaxValue() => float.MaxValue;
         public readonly float2 MaxValue2() => float.MaxValue;
         public readonly float MaxDistSq() => float.MaxValue;
@@ -2869,7 +2862,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly float dot(float2 a, float2 b) => math.dot(a, b);
         public readonly bool eq(float v, float w) => v == w;
         public readonly bool2 eq(float2 v, float2 w) => v == w;
-        public readonly bool ge(float a, float b) => a >= b;
         public readonly bool2 ge(float2 a, float2 b) => a >= b;
         public readonly bool greater(float a, float b) => a > b;
         public readonly int hashkey(float2 p, float2 c, int hashSize)
@@ -2886,19 +2878,15 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly bool le(float a, float b) => a <= b;
         public readonly bool2 le(float2 a, float2 b) => a <= b;
         public readonly bool less(float a, float b) => a < b;
-        public readonly float max(float v, float w) => math.max(v, w);
         public readonly float2 max(float2 v, float2 w) => math.max(v, w);
         public readonly float2 min(float2 v, float2 w) => math.min(v, w);
         public readonly float mul(float a, float b) => a * b;
-        public readonly float neg(float v) => -v;
-        public readonly float2 neg(float2 v) => -v;
     }
 
     internal readonly struct DoubleUtils : IUtils<double, double2, double>
     {
         public readonly double ConstTBig(float v) => v;
-        public readonly double EPSILON() => math.EPSILON_DBL;
-        public readonly double EPSILON_TBIG() => EPSILON();
+        public readonly double EPSILON_TBIG() => math.EPSILON_DBL;
         public readonly double MaxValue() => double.MaxValue;
         public readonly double2 MaxValue2() => double.MaxValue;
         public readonly double MaxDistSq() => double.MaxValue;
@@ -2986,7 +2974,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly double dot(double2 a, double2 b) => math.dot(a, b);
         public readonly bool eq(double v, double w) => v == w;
         public readonly bool2 eq(double2 v, double2 w) => v == w;
-        public readonly bool ge(double a, double b) => a >= b;
         public readonly bool2 ge(double2 a, double2 b) => a >= b;
         public readonly bool greater(double a, double b) => a > b;
         public readonly int hashkey(double2 p, double2 c, int hashSize)
@@ -3003,18 +2990,14 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly bool le(double a, double b) => a <= b;
         public readonly bool2 le(double2 a, double2 b) => a <= b;
         public readonly bool less(double a, double b) => a < b;
-        public readonly double max(double v, double w) => math.max(v, w);
         public readonly double2 max(double2 v, double2 w) => math.max(v, w);
         public readonly double2 min(double2 v, double2 w) => math.min(v, w);
         public readonly double mul(double a, double b) => a * b;
-        public readonly double neg(double v) => -v;
-        public readonly double2 neg(double2 v) => -v;
     }
 
     internal readonly struct IntUtils : IUtils<int, int2, long>
     {
         public readonly long ConstTBig(float v) => (long)v;
-        public readonly int EPSILON() => 0;
         public readonly long EPSILON_TBIG() => 0;
         public readonly int MaxValue() => int.MaxValue;
         public readonly int2 MaxValue2() => int.MaxValue;
@@ -3107,7 +3090,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly long dot(int2 a, int2 b) => (long)a.x * b.x + (long)a.y * b.y;
         public readonly bool eq(int v, int w) => v == w;
         public readonly bool2 eq(int2 v, int2 w) => v == w;
-        public readonly bool ge(int a, int b) => a >= b;
         public readonly bool2 ge(int2 a, int2 b) => a >= b;
         public readonly bool greater(int a, int b) => a > b;
         public readonly bool greater(long a, long b) => a > b;
@@ -3128,17 +3110,13 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         // since some algorithms may fail with very large coordinates.
         // TODO: Validate really large coordinates with tests
         public readonly bool2 isfinite(int2 v) => math.all(math.abs(v) < (1 << 20));
-        public readonly bool le(int a, int b) => a <= b;
         public readonly bool2 le(int2 a, int2 b) => a <= b;
         public readonly bool le(long a, long b) => a <= b;
         public readonly bool less(int a, int b) => a < b;
         public readonly bool less(long a, long b) => a < b;
-        public readonly int max(int v, int w) => math.max(v, w);
         public readonly int2 max(int2 v, int2 w) => math.max(v, w);
         public readonly int2 min(int2 v, int2 w) => math.min(v, w);
         public readonly long mul(int a, int b) => (long)a * b;
         public readonly long mul(long a, long b) => a * b;
-        public readonly int neg(int v) => -v;
-        public readonly int2 neg(int2 v) => -v;
     }
 }

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2746,6 +2746,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// D is a float for all coordinate types (even when using doubles), because the precision
         /// of it is not important for the algorithm, and this avoids us having to introduce yet another generic type parameter.
         /// </summary>
+        /// <param name="initial"/>If true, then e1 and e2 are swapped</param>
         T2 PickPointOnConcentricShell(float D, T2 e1, T2 e2, bool initial);
 
         /// <summary>

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2761,7 +2761,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         TBig diff(TBig a, TBig b);
         T2 diff(T2 a, T2 b);
         TBig distancesq(T2 a, T2 b);
-        T div(T a, T b);
         TBig dot(T2 a, T2 b);
         bool eq(T v, T w);
         bool2 eq(T2 v, T2 w);
@@ -2878,7 +2877,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly float diff(float a, float b) => a - b;
         public readonly float2 diff(float2 a, float2 b) => a - b;
         public readonly float distancesq(float2 a, float2 b) => math.distancesq(a, b);
-        public readonly float div(float a, float b) => a / b;
         public readonly float dot(float2 a, float2 b) => math.dot(a, b);
         public readonly bool eq(float v, float w) => v == w;
         public readonly bool2 eq(float2 v, float2 w) => v == w;
@@ -2999,7 +2997,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly double diff(double a, double b) => a - b;
         public readonly double2 diff(double2 a, double2 b) => a - b;
         public readonly double distancesq(double2 a, double2 b) => math.distancesq(a, b);
-        public readonly double div(double a, double b) => a / b;
         public readonly double dot(double2 a, double2 b) => math.dot(a, b);
         public readonly bool eq(double v, double w) => v == w;
         public readonly bool2 eq(double2 v, double2 w) => v == w;
@@ -3136,7 +3133,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             var d = a - b;
             return (long)d.x * (long)d.x + (long)d.y * (long)d.y;
         }
-        public readonly int div(int a, int b) => a / b;
         public readonly long dot(int2 a, int2 b) => (long)a.x * b.x + (long)a.y * b.y;
         public readonly bool eq(int v, int w) => v == w;
         public readonly bool2 eq(int2 v, int2 w) => v == w;

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -478,7 +478,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         private void PreProcessInputStep(InputData<T2> input, OutputData<T2> output, Args args, out NativeArray<T2> localHoles, out TTransform lt, Allocator allocator)
         {
-            // TODO: Create markers statically, to reduce overhead
             using var _ = new ProfilerMarker($"{nameof(PreProcessInputStep)}").Auto();
 
             var localPositions = output.Positions;

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2812,7 +2812,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         static float cross(float2 a, float2 b) => a.x * b.y - a.y * b.x;
 
         public readonly bool PointInsideTriangle(float2 p, float2 a, float2 b, float2 c) {
-            float3 Barycentric(float2 a, float2 b, float2 c, float2 p) {
+            float3 bar(float2 a, float2 b, float2 c, float2 p) {
                 var (v0, v1, v2) = (b - a, c - a, p - a);
                 var denInv = 1 / cross(v0, v1);
                 var v = denInv * cross(v2, v1);
@@ -2821,7 +2821,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 return new float3(u, v, w);
             }
 
-            return math.cmax(-Barycentric(a, b, c, p)) <= 0;;
+            return math.cmax(-bar(a, b, c, p)) <= 0;;
         }
 
         public readonly float2 CircumCenter(float2 a, float2 b, float2 c) {

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -369,13 +369,13 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
     }
 
     [BurstCompile]
-    internal struct TriangulationJob<T, T2, TFloat, TDistSq, TTransform, TUtils> : IJob
+    internal struct TriangulationJob<T, T2, TFloat, TSquare, TTransform, TUtils> : IJob
         where T : unmanaged, IComparable<T>
         where T2 : unmanaged
         where TFloat : unmanaged, IComparable<TFloat>
-        where TDistSq : unmanaged, IComparable<TDistSq>
-        where TTransform : unmanaged, ITransform<TTransform, T, T2, TDistSq>
-        where TUtils : unmanaged, IUtils<T, T2, TFloat, TDistSq>
+        where TSquare : unmanaged, IComparable<TSquare>
+        where TTransform : unmanaged, ITransform<TTransform, T, T2, TSquare>
+        where TUtils : unmanaged, IUtils<T, T2, TFloat, TSquare>
     {
         private NativeArray<T2> inputPositions;
         [NativeDisableContainerSafetyRestriction]
@@ -408,7 +408,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public void Execute()
         {
-            new UnsafeTriangulator<T, T2, TFloat, TDistSq, TTransform, TUtils>().Triangulate(
+            new UnsafeTriangulator<T, T2, TFloat, TSquare, TTransform, TUtils>().Triangulate(
                 input: new()
                 {
                     Positions = inputPositions,

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2465,10 +2465,10 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         private static int NextHalfedge(int he) => he % 3 == 2 ? he - 2 : he + 1;
         private static bool InCircle(T2 a, T2 b, T2 c, T2 p) => utils.InCircle(a, b, c, p);
         internal static bool IsConvexQuadrilateral(T2 a, T2 b, T2 c, T2 d) => true
-            && utils.greater(utils.abs(Orient2dFast(a, c, b)), utils.EPSILON_SQ())
-            && utils.greater(utils.abs(Orient2dFast(a, c, d)), utils.EPSILON_SQ())
-            && utils.greater(utils.abs(Orient2dFast(b, d, a)), utils.EPSILON_SQ())
-            && utils.greater(utils.abs(Orient2dFast(b, d, c)), utils.EPSILON_SQ())
+            && utils.greater(utils.abs(Orient2dFast(a, c, b)), utils.EPSILON_TBIG())
+            && utils.greater(utils.abs(Orient2dFast(a, c, d)), utils.EPSILON_TBIG())
+            && utils.greater(utils.abs(Orient2dFast(b, d, a)), utils.EPSILON_TBIG())
+            && utils.greater(utils.abs(Orient2dFast(b, d, c)), utils.EPSILON_TBIG())
             && EdgeEdgeIntersection(a, c, b, d)
         ;
         private static TBig Orient2dFast(T2 a, T2 b, T2 c) => utils.diff(
@@ -2476,7 +2476,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             utils.mul(utils.diff(utils.X(a), utils.X(c)), utils.diff(utils.Y(b), utils.Y(c)))
         );
         internal static bool PointLineSegmentIntersection(T2 a, T2 b0, T2 b1) => true
-            && utils.le(utils.abs(Orient2dFast(a, b0, b1)), utils.EPSILON_SQ())
+            && utils.le(utils.abs(Orient2dFast(a, b0, b1)), utils.EPSILON_TBIG())
             && math.all(utils.ge(a, utils.min(b0, b1)) & utils.le(a, utils.max(b0, b1)));
         internal static bool PointInsideTriangle(T2 p, T2 a, T2 b, T2 c) => utils.PointInsideTriangle(p, a, b, c);
     }
@@ -2747,7 +2747,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// </summary>
         TFloat ConstFloat(float v);
         T EPSILON();
-        TBig EPSILON_SQ();
+        TBig EPSILON_TBIG();
         T MaxValue();
         T2 MaxValue2();
         TBig MaxDistSq();
@@ -2810,7 +2810,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly float ConstDistanceSq(float v) => v;
         public readonly float ConstFloat(float v) => v;
         public readonly float EPSILON() => math.EPSILON;
-        public readonly float EPSILON_SQ() => EPSILON();
+        public readonly float EPSILON_TBIG() => EPSILON();
         public readonly float MaxValue() => float.MaxValue;
         public readonly float2 MaxValue2() => float.MaxValue;
         public readonly float MaxDistSq() => float.MaxValue;
@@ -2918,7 +2918,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly double ConstDistanceSq(float v) => v;
         public readonly double ConstFloat(float v) => v;
         public readonly double EPSILON() => math.EPSILON_DBL;
-        public readonly double EPSILON_SQ() => EPSILON();
+        public readonly double EPSILON_TBIG() => EPSILON();
         public readonly double MaxValue() => double.MaxValue;
         public readonly double2 MaxValue2() => double.MaxValue;
         public readonly double MaxDistSq() => double.MaxValue;
@@ -3026,7 +3026,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly long ConstDistanceSq(float v) => (long)v;
         public readonly float ConstFloat(float v) => v;
         public readonly int EPSILON() => 0;
-        public readonly long EPSILON_SQ() => 0;
+        public readonly long EPSILON_TBIG() => 0;
         public readonly int MaxValue() => int.MaxValue;
         public readonly int2 MaxValue2() => int.MaxValue;
         public readonly long MaxDistSq() => long.MaxValue;

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2697,12 +2697,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         }
     }
 
-    /// <summary>
-    /// Helper interface for math operations that are generic over the coordinate type.
-    /// </summary>
-    /// <typeparam name="T">The raw coordinate type for a single axis. For example float or int.</typeparam>
-    /// <typeparam name="T2">The 2D coordinate composed of Ts. For example float2.</typeparam>
-    /// <typeparam name="TBig">A value that may have higher precision compared to T. Used for squared distances and other products.</typeparam>
     internal interface IUtils<T, T2, TBig> where T : unmanaged where T2 : unmanaged where TBig : unmanaged
     {
         /// <summary>

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -244,19 +244,19 @@ namespace andywiecko.BurstTriangulator
         }
 
         public static void Run(this Triangulator<float2> @this) =>
-            new TriangulationJob<float, float2, float, float, AffineTransform32, FloatUtils>(@this).Run();
+            new TriangulationJob<float, float2, float, AffineTransform32, FloatUtils>(@this).Run();
         public static JobHandle Schedule(this Triangulator<float2> @this, JobHandle dependencies = default) =>
-            new TriangulationJob<float, float2, float, float, AffineTransform32, FloatUtils>(@this).Schedule(dependencies);
+            new TriangulationJob<float, float2, float, AffineTransform32, FloatUtils>(@this).Schedule(dependencies);
 
         public static void Run(this Triangulator<double2> @this) =>
-            new TriangulationJob<double, double2, double, double, AffineTransform64, DoubleUtils>(@this).Run();
+            new TriangulationJob<double, double2, double, AffineTransform64, DoubleUtils>(@this).Run();
         public static JobHandle Schedule(this Triangulator<double2> @this, JobHandle dependencies = default) =>
-            new TriangulationJob<double, double2, double, double, AffineTransform64, DoubleUtils>(@this).Schedule(dependencies);
+            new TriangulationJob<double, double2, double, AffineTransform64, DoubleUtils>(@this).Schedule(dependencies);
 
         public static void Run(this Triangulator<int2> @this) =>
-            new TriangulationJob<int, int2, float, long, TranslationInt32, IntUtils>(@this).Run();
+            new TriangulationJob<int, int2, long, TranslationInt32, IntUtils>(@this).Run();
         public static JobHandle Schedule(this Triangulator<int2> @this, JobHandle dependencies = default) =>
-            new TriangulationJob<int, int2, float, long, TranslationInt32, IntUtils>(@this).Schedule(dependencies);
+            new TriangulationJob<int, int2, long, TranslationInt32, IntUtils>(@this).Schedule(dependencies);
     }
 }
 
@@ -347,33 +347,32 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
     public static class Extensions
     {
-        public static void Triangulate(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
-        public static void PlantHoleSeeds(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
         public static void RefineMesh(this UnsafeTriangulator @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, (float)concentricShells, constrainBoundary);
+            new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, (float)angleThreshold, (float)concentricShells, constrainBoundary);
 
-        public static void Triangulate(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, float, AffineTransform32, FloatUtils>().Triangulate(input, output, args, allocator);
-        public static void PlantHoleSeeds(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, float, AffineTransform32, FloatUtils>().PlantHoleSeeds(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().Triangulate(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().PlantHoleSeeds(input, output, args, allocator);
         public static void RefineMesh(this UnsafeTriangulator<float2> @this, OutputData<float2> output, Allocator allocator, float areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<float, float2, float, float, AffineTransform32, FloatUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+            new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
 
-        public static void Triangulate(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
-        public static void PlantHoleSeeds(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
         public static void RefineMesh(this UnsafeTriangulator<double2> @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, (float)concentricShells, constrainBoundary);
+            new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, (float)angleThreshold, (float)concentricShells, constrainBoundary);
 
-        public static void Triangulate(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, float, long, TranslationInt32, IntUtils>().Triangulate(input, output, args, allocator);
-        public static void PlantHoleSeeds(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, float, long, TranslationInt32, IntUtils>().PlantHoleSeeds(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TranslationInt32, IntUtils>().Triangulate(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TranslationInt32, IntUtils>().PlantHoleSeeds(input, output, args, allocator);
     }
 
     [BurstCompile]
-    internal struct TriangulationJob<T, T2, TFloat, TBig, TTransform, TUtils> : IJob
+    internal struct TriangulationJob<T, T2, TBig, TTransform, TUtils> : IJob
         where T : unmanaged, IComparable<T>
         where T2 : unmanaged
-        where TFloat : unmanaged, IComparable<TFloat>
         where TBig : unmanaged, IComparable<TBig>
         where TTransform : unmanaged, ITransform<TTransform, T, T2, TBig>
-        where TUtils : unmanaged, IUtils<T, T2, TFloat, TBig>
+        where TUtils : unmanaged, IUtils<T, T2, TBig>
     {
         private NativeArray<T2> inputPositions;
         [NativeDisableContainerSafetyRestriction]
@@ -406,7 +405,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public void Execute()
         {
-            new UnsafeTriangulator<T, T2, TFloat, TBig, TTransform, TUtils>().Triangulate(
+            new UnsafeTriangulator<T, T2, TBig, TTransform, TUtils>().Triangulate(
                 input: new()
                 {
                     Positions = inputPositions,
@@ -424,13 +423,12 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         }
     }
 
-    internal readonly struct UnsafeTriangulator<T, T2, TFloat, TBig, TTransform, TUtils>
+    internal readonly struct UnsafeTriangulator<T, T2, TBig, TTransform, TUtils>
         where T : unmanaged, IComparable<T>
         where T2 : unmanaged
-        where TFloat : unmanaged, IComparable<TFloat>
         where TBig : unmanaged, IComparable<TBig>
         where TTransform : unmanaged, ITransform<TTransform, T, T2, TBig>
-        where TUtils : unmanaged, IUtils<T, T2, TFloat, TBig>
+        where TUtils : unmanaged, IUtils<T, T2, TBig>
     {
         private static readonly TUtils utils = default;
 
@@ -471,7 +469,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             new PlantingSeedStep(input, output, args).Execute(allocator, true);
         }
 
-        public void RefineMesh(OutputData<T2> output, Allocator allocator, TBig area2Threshold, TFloat angleThreshold, float shells, bool constrainBoundary = false)
+        public void RefineMesh(OutputData<T2> output, Allocator allocator, TBig area2Threshold, float angleThreshold, float shells, bool constrainBoundary = false)
         {
             new RefineMeshStep(output, area2Threshold, angleThreshold, shells).Execute(allocator, refineMesh: true, constrainBoundary);
         }
@@ -1304,7 +1302,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             {
                 var (a0, a1) = (positions[e1.x], positions[e1.y]);
                 var (b0, b1) = (positions[e2.x], positions[e2.y]);
-                return !(math.any(e1.xy == e2.xy | e1.xy == e2.yx)) && UnsafeTriangulator<T, T2, TFloat, TBig, TTransform, TUtils>.EdgeEdgeIntersection(a0, a1, b0, b1);
+                return !(math.any(e1.xy == e2.xy | e1.xy == e2.yx)) && UnsafeTriangulator<T, T2, TBig, TTransform, TUtils>.EdgeEdgeIntersection(a0, a1, b0, b1);
             }
 
             private void CollectIntersections(int2 edge)
@@ -1774,21 +1772,21 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             private readonly TBig maximumArea2;
             private readonly float shells;
-            private readonly TFloat angleThreshold;
+            private readonly float cosAngleThreshold;
             private readonly int initialPointsCount;
 
             public RefineMeshStep(OutputData<T2> output, Args args, TTransform lt) : this(output,
                 area2Threshold: utils.mul(utils.ConstDistanceSq(2), lt.TransformArea(utils.ConstDistanceSq(args.RefinementThresholdArea))),
-                angleThreshold: utils.ConstFloat(args.RefinementThresholdAngle),
+                angleThreshold: args.RefinementThresholdAngle,
                 shells: args.ConcentricShellsParameter)
             { }
 
-            public RefineMeshStep(OutputData<T2> output, TBig area2Threshold, TFloat angleThreshold, float shells)
+            public RefineMeshStep(OutputData<T2> output, TBig area2Threshold, float angleThreshold, float shells)
             {
                 status = output.Status;
                 initialPointsCount = output.Positions.Length;
                 maximumArea2 = area2Threshold;
-                this.angleThreshold = angleThreshold;
+                cosAngleThreshold = math.cos(angleThreshold);
                 this.shells = shells;
                 triangles = output.Triangles;
                 outputPositions = output.Positions;
@@ -2003,7 +2001,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 var (i, j, k) = (triangles[3 * tId + 0], triangles[3 * tId + 1], triangles[3 * tId + 2]);
                 var (a, b, c) = (outputPositions[i], outputPositions[j], outputPositions[k]);
                 var area2 = Area2(a, b, c);
-                return utils.greater(area2, maximumArea2) || AngleIsTooSmall(tId, angleThreshold);
+                return utils.greater(area2, maximumArea2) || AngleIsTooSmall(tId, cosAngleThreshold);
             }
 
             private void SplitTriangle(int tId, NativeList<int> heQueue, NativeList<int> tQueue, Allocator allocator)
@@ -2056,22 +2054,11 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private bool AngleIsTooSmall(int tId, TFloat minimumAngle)
+            private bool AngleIsTooSmall(int tId, float cosMinimumAngle)
             {
                 var (i, j, k) = (triangles[3 * tId + 0], triangles[3 * tId + 1], triangles[3 * tId + 2]);
                 var (pA, pB, pC) = (outputPositions[i], outputPositions[j], outputPositions[k]);
-
-                var pAB = utils.diff(pB, pA);
-                var pBC = utils.diff(pC, pB);
-                var pCA = utils.diff(pA, pC);
-
-                // TODO: Can be done faster using dot products
-                return utils.anyabslessthan(
-                    a: Angle(pAB, utils.neg(pCA)),
-                    b: Angle(pBC, utils.neg(pAB)),
-                    c: Angle(pCA, utils.neg(pBC)),
-                    v: minimumAngle
-                );
+                return utils.SmallestInnerAngleIsBelowThreshold(pA, pB, pC, cosMinimumAngle);
             }
 
             private int UnsafeInsertPointCommon(T2 p, int initTriangle)
@@ -2439,7 +2426,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
         }
 
-        internal static TFloat Angle(T2 a, T2 b) => utils.atan2(Cross(a, b), utils.dot(a, b));
         internal static TBig Area2(T2 a, T2 b, T2 c) => utils.abs(Cross(utils.diff(b, a), utils.diff(c, a)));
         private static TBig Cross(T2 a, T2 b) => utils.diff(utils.mul(utils.X(a), utils.Y(b)), utils.mul(utils.Y(a), utils.X(b)));
         private static T2 CircumCenter(T2 a, T2 b, T2 c) => utils.CircumCenter(a,b,c);
@@ -2723,9 +2709,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
     /// </summary>
     /// <typeparam name="T">The raw coordinate type for a single axis. For example float or int.</typeparam>
     /// <typeparam name="T2">The 2D coordinate composed of Ts. For example float2.</typeparam>
-    /// <typeparam name="TFloat">A floating point value. Used for angles and fractional values. For example float.</typeparam>
     /// <typeparam name="TBig">A value that may have higher precision compared to T. Used for squared distances and other products.</typeparam>
-    internal interface IUtils<T, T2, TFloat, TBig> where T : unmanaged where T2 : unmanaged where TFloat : unmanaged where TBig : unmanaged
+    internal interface IUtils<T, T2, TBig> where T : unmanaged where T2 : unmanaged where TBig : unmanaged
     {
         /// <summary>
         /// Converts a value to type T.
@@ -2739,12 +2724,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// Warning: This may cause loss of precision, and is only safe for (not huge) integer constants.
         /// </summary>
         TBig ConstDistanceSq(float v);
-        /// <summary>
-        /// Converts a value to type TFloat.
-        ///
-        /// Warning: This may cause loss of precision, but it always supports fractional values.
-        /// </summary>
-        TFloat ConstFloat(float v);
         T EPSILON();
         TBig EPSILON_TBIG();
         T MaxValue();
@@ -2775,10 +2754,14 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// of it is not important for the algorithm, and this avoids us having to introduce yet another generic type parameter.
         /// </summary>
         T2 PickPointOnConcentricShell(float D, T2 e1, T2 e2, bool initial);
-        bool anyabslessthan(TFloat a, TFloat b, TFloat c, TFloat v);
-        // Note: Takes TBig arguments, even if that's not technically correct for an atan2 function.
-        // It is used like atan2(a*C, b*C) where C is a length of type T.
-        TFloat atan2(TBig v, TBig w);
+
+        /// <summary>
+        /// Returns true if the smallest inner angle of the triangle (a, b, c) is below the given threshold.
+        /// Degenerate (zero area) triangles are considered to have a smallest inner angle of 0.
+        /// </summary>
+        /// <param name="cosAngle">Cosine of the threshold angle. This is a float for all coordinate types (even when using doubles),
+        /// because the precision of it is not important for the algorithm.</param>
+        bool SmallestInnerAngleIsBelowThreshold(T2 a, T2 b, T2 c, float cosAngle);
         T2 avg(T2 a, T2 b);
         T diff(T a, T b);
         TBig diff(TBig a, TBig b);
@@ -2809,11 +2792,10 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 #pragma warning restore IDE1006
     }
 
-    internal readonly struct FloatUtils : IUtils<float, float2, float, float>
+    internal readonly struct FloatUtils : IUtils<float, float2, float>
     {
         public readonly float Const(int v) => v;
         public readonly float ConstDistanceSq(float v) => v;
-        public readonly float ConstFloat(float v) => v;
         public readonly float EPSILON() => math.EPSILON;
         public readonly float EPSILON_TBIG() => EPSILON();
         public readonly float MaxValue() => float.MaxValue;
@@ -2880,11 +2862,24 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             return math.lerp(e1, e2, alpha);
         }
 
+        public readonly bool SmallestInnerAngleIsBelowThreshold(float2 a, float2 b, float2 c, float cosAngle) {
+            var ab = math.normalizesafe(b - a);
+            var bc = math.normalizesafe(c - b);
+            var ca = math.normalizesafe(a - c);
+            var lab = math.length(ab);
+            var lbc = math.length(bc);
+            var lca = math.length(ca);
+            // Necessary to handle degenerate triangles, for which the smallest inner angle should be zero.
+            if (math.any(new double3(lab, lbc, lca) < math.FLT_MIN_NORMAL)) return cosAngle < 1;
+            ab /= lab;
+            bc /= lbc;
+            ca /= lca;
+            return math.any(new float3(math.dot(ab, -ca), math.dot(bc, -ab), math.dot(ca, -bc)) > cosAngle);
+        }
+
         public readonly float abs(float v) => math.abs(v);
         public readonly float add(float a, float b) => a + b;
 
-        public readonly bool anyabslessthan(float a, float b, float c, float v) => math.any(math.abs(math.float3(a, b, c)) < v);
-        public readonly float atan2(float a, float b) => math.atan2(a, b);
         public readonly float2 avg(float2 a, float2 b) => 0.5f * (a + b);
         public readonly float diff(float a, float b) => a - b;
         public readonly float2 diff(float2 a, float2 b) => a - b;
@@ -2918,11 +2913,10 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly float2 neg(float2 v) => -v;
     }
 
-    internal readonly struct DoubleUtils : IUtils<double, double2, double, double>
+    internal readonly struct DoubleUtils : IUtils<double, double2, double>
     {
         public readonly double Const(int v) => v;
         public readonly double ConstDistanceSq(float v) => v;
-        public readonly double ConstFloat(float v) => v;
         public readonly double EPSILON() => math.EPSILON_DBL;
         public readonly double EPSILON_TBIG() => EPSILON();
         public readonly double MaxValue() => double.MaxValue;
@@ -2989,10 +2983,24 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             return math.lerp(e1, e2, alpha);
         }
 
+        public readonly bool SmallestInnerAngleIsBelowThreshold(double2 a, double2 b, double2 c, float cosAngle) {
+            var ab = b - a;
+            var bc = c - b;
+            var ca = a - c;
+            var lab = math.length(ab);
+            var lbc = math.length(bc);
+            var lca = math.length(ca);
+            // Necessary to handle degenerate triangles, for which the smallest inner angle should be zero.
+            // TODO: Will this method ever have to handle degenerate triangles?
+            if (math.any(new double3(lab, lbc, lca) < math.FLT_MIN_NORMAL)) return cosAngle < 1;
+            ab /= lab;
+            bc /= lbc;
+            ca /= lca;
+            return math.any(new double3(math.dot(ab, -ca), math.dot(bc, -ab), math.dot(ca, -bc)) > cosAngle);
+        }
+
         public readonly double abs(double v) => math.abs(v);
         public readonly double add(double a, double b) => a + b;
-        public readonly bool anyabslessthan(double a, double b, double c, double v) => math.any(math.abs(math.double3(a, b, c)) < v);
-        public readonly double atan2(double a, double b) => math.atan2(a, b);
         public readonly double2 avg(double2 a, double2 b) => 0.5f * (a + b);
         public readonly double diff(double a, double b) => a - b;
         public readonly double2 diff(double2 a, double2 b) => a - b;
@@ -3026,11 +3034,10 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly double2 neg(double2 v) => -v;
     }
 
-    internal readonly struct IntUtils : IUtils<int, int2, float, long>
+    internal readonly struct IntUtils : IUtils<int, int2, long>
     {
         public readonly int Const(int v) => v;
         public readonly long ConstDistanceSq(float v) => (long)v;
-        public readonly float ConstFloat(float v) => v;
         public readonly int EPSILON() => 0;
         public readonly long EPSILON_TBIG() => 0;
         public readonly int MaxValue() => int.MaxValue;
@@ -3108,12 +3115,25 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             return e1 + (int2)math.round((double2)(e2 - e1) * alpha);
         }
 
+        public readonly bool SmallestInnerAngleIsBelowThreshold(int2 a, int2 b, int2 c, float cosAngle) {
+            var ab = b - a;
+            var bc = c - b;
+            var ca = a - c;
+            var lab = dot(ab, ab);
+            var lbc = dot(bc, bc);
+            var lca = dot(ca, ca);
+            // Necessary to handle degenerate triangles, for which the smallest inner angle should be zero.
+            if (lab == 0 || lbc == 0 || lca == 0) return cosAngle < 1;
+            if ((double)dot(ab, -ca) > cosAngle * math.sqrt((double)lab * (double)lca)) return true;
+            if ((double)dot(bc, -ab) > cosAngle * math.sqrt((double)lbc * (double)lab)) return true;
+            if ((double)dot(ca, -bc) > cosAngle * math.sqrt((double)lca * (double)lbc)) return true;
+            return false;
+        }
+
         public readonly int abs(int v) => math.abs(v);
         public readonly long abs(long v) => math.abs(v);
         public readonly int add(int a, int b) => a + b;
         public readonly long add(long a, long b) => a + b;
-        public readonly bool anyabslessthan(float a, float b, float c, float v) => math.any(math.abs(math.double3(a, b, c)) < v);
-        public readonly float atan2(long a, long b) => throw new NotImplementedException();
         public readonly int2 avg(int2 a, int2 b) => (a + b)/2;
         public readonly int diff(int a, int b) => a - b;
         public readonly long diff(long a, long b) => a - b;

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -1,7 +1,6 @@
 using andywiecko.BurstTriangulator.LowLevel.Unsafe;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Runtime.CompilerServices;
 using Unity.Burst;
 using Unity.Collections;
@@ -255,9 +254,9 @@ namespace andywiecko.BurstTriangulator
             new TriangulationJob<double, double2, double, AffineTransform64, DoubleUtils>(@this).Schedule(dependencies);
 
         public static void Run(this Triangulator<int2> @this) =>
-            new TriangulationJob<int, int2, long, TranslationInt32, IntUtils>(@this).Run();
+            new TriangulationJob<int, int2, long, TranslationInt, IntUtils>(@this).Run();
         public static JobHandle Schedule(this Triangulator<int2> @this, JobHandle dependencies = default) =>
-            new TriangulationJob<int, int2, long, TranslationInt32, IntUtils>(@this).Schedule(dependencies);
+            new TriangulationJob<int, int2, long, TranslationInt, IntUtils>(@this).Schedule(dependencies);
     }
 }
 
@@ -351,7 +350,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public static void Triangulate(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
         public static void PlantHoleSeeds(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
         public static void RefineMesh(this UnsafeTriangulator @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, (float)angleThreshold, (float)concentricShells, constrainBoundary);
+            new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
 
         public static void Triangulate(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().Triangulate(input, output, args, allocator);
         public static void PlantHoleSeeds(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().PlantHoleSeeds(input, output, args, allocator);
@@ -361,10 +360,10 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public static void Triangulate(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
         public static void PlantHoleSeeds(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
         public static void RefineMesh(this UnsafeTriangulator<double2> @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, (float)angleThreshold, (float)concentricShells, constrainBoundary);
+            new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
 
-        public static void Triangulate(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TranslationInt32, IntUtils>().Triangulate(input, output, args, allocator);
-        public static void PlantHoleSeeds(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TranslationInt32, IntUtils>().PlantHoleSeeds(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TranslationInt, IntUtils>().Triangulate(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TranslationInt, IntUtils>().PlantHoleSeeds(input, output, args, allocator);
     }
 
     [BurstCompile]
@@ -372,7 +371,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         where T : unmanaged, IComparable<T>
         where T2 : unmanaged
         where TBig : unmanaged, IComparable<TBig>
-        where TTransform : unmanaged, ITransform<TTransform, T, T2, TBig>
+        where TTransform : unmanaged, ITransform<TTransform, T, T2>
         where TUtils : unmanaged, IUtils<T, T2, TBig>
     {
         private NativeArray<T2> inputPositions;
@@ -428,7 +427,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         where T : unmanaged, IComparable<T>
         where T2 : unmanaged
         where TBig : unmanaged, IComparable<TBig>
-        where TTransform : unmanaged, ITransform<TTransform, T, T2, TBig>
+        where TTransform : unmanaged, ITransform<TTransform, T, T2>
         where TUtils : unmanaged, IUtils<T, T2, TBig>
     {
         private static readonly TUtils utils = default;
@@ -470,7 +469,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             new PlantingSeedStep(input, output, args).Execute(allocator, true);
         }
 
-        public void RefineMesh(OutputData<T2> output, Allocator allocator, TBig area2Threshold, float angleThreshold, float shells, bool constrainBoundary = false)
+        public void RefineMesh(OutputData<T2> output, Allocator allocator, T area2Threshold, T angleThreshold, T shells, bool constrainBoundary = false)
         {
             new RefineMeshStep(output, area2Threshold, angleThreshold, shells).Execute(allocator, refineMesh: true, constrainBoundary);
         }
@@ -736,7 +735,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 hullStart = int.MaxValue;
                 c = utils.MaxValue2();
                 verbose = args.Verbose;
-                // TODO: Use a power of two and bitwise AND to improve performance
                 hashSize = (int)math.ceil(math.sqrt(positions.Length));
                 trianglesLen = default;
 
@@ -783,7 +781,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 var center = utils.avg(min, max);
 
                 int i0 = int.MaxValue, i1 = int.MaxValue, i2 = int.MaxValue;
-                var minDistSq = utils.MaxDistSq();
+                var minDistSq = utils.MaxValue();
                 for (int i = 0; i < positions.Length; i++)
                 {
                     var distSq = utils.distancesq(center, positions[i]);
@@ -797,7 +795,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 // Centermost vertex
                 var p0 = positions[i0];
 
-                minDistSq = utils.MaxDistSq();
+                minDistSq = utils.MaxValue();
                 for (int i = 0; i < positions.Length; i++)
                 {
                     if (i == i0) continue;
@@ -812,16 +810,16 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 // Second closest to the center
                 var p1 = positions[i1];
 
-                var minRadiusSq = utils.MaxDistSq();
+                var minRadius = utils.MaxValue();
                 for (int i = 0; i < positions.Length; i++)
                 {
                     if (i == i0 || i == i1) continue;
                     var p = positions[i];
                     var r = CircumRadiusSq(p0, p1, p);
-                    if (utils.less(r, minRadiusSq))
+                    if (utils.less(r, minRadius))
                     {
                         i2 = i;
-                        minRadiusSq = r;
+                        minRadius = r;
                     }
                 }
 
@@ -830,7 +828,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 // are no other vertices inside this triangle.
                 var p2 = positions[i2];
 
-                if (minRadiusSq.CompareTo(utils.MaxDistSq()) == 0)
+                if (minRadius.CompareTo(utils.MaxValue()) == 0)
                 {
                     if (verbose)
                     {
@@ -848,7 +846,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 }
 
                 // Sort all other vertices by their distance to the circumcenter of the initial triangle
-                c = CircumCenter(p0, p1, p2);
+                c = utils.CircumCenter(p0, p1, p2);
                 for (int i = 0; i < positions.Length; i++)
                 {
                     dists[i] = utils.distancesq(c, positions[i]);
@@ -882,9 +880,9 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
                     // Find a visible edge on the convex hull using edge hash
                     var start = 0;
-                    var key = utils.hashkey(p, c, hashSize);
                     for (var j = 0; j < hashSize; j++)
                     {
+                        var key = utils.hashkey(p, c, hashSize);
                         start = hullHash[(key + j) % hashSize];
                         if (start != -1 && start != hullNext[start]) break;
                     }
@@ -1009,7 +1007,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     var pl = triangles[al];
                     var p1 = triangles[bl];
 
-                    var illegal = InCircle(positions[p0], positions[pr], positions[pl], positions[p1]);
+                    var illegal = utils.InCircle(positions[p0], positions[pr], positions[pl], positions[p1]);
 
                     if (illegal)
                     {
@@ -1606,7 +1604,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 {
                     var (i, j, k) = (triangles[3 * tId + 0], triangles[3 * tId + 1], triangles[3 * tId + 2]);
                     var (a, b, c) = (positions[i], positions[j], positions[k]);
-                    if (PointInsideTriangle(p, a, b, c))
+                    if (utils.PointInsideTriangle(p, a, b, c))
                     {
                         return tId;
                     }
@@ -1745,10 +1743,10 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private readonly struct Circle
             {
                 public readonly T2 Center;
-                public readonly TBig RadiusSq;
+                public readonly T RadiusSq;
                 private readonly T offset;
-                public Circle(T2 center, TBig radiusSq) => (Center, RadiusSq, offset) = (center, radiusSq, default);
-                public Circle((T2 center, TBig radiusSq) circle) => (Center, RadiusSq, offset) = (circle.center, circle.radiusSq, default);
+                public Circle(T2 center, T radiusSq) => (Center, RadiusSq, offset) = (center, radiusSq, default);
+                public Circle((T2 center, T radiusSq) circle) => (Center, RadiusSq, offset) = (circle.center, circle.radiusSq, default);
             }
 
             private NativeReference<Status> status;
@@ -1764,18 +1762,16 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private NativeList<int> pathHalfedges;
             private NativeList<bool> visitedTriangles;
 
-            private readonly TBig maximumArea2;
-            private readonly float shells;
-            private readonly float angleThreshold;
+            private readonly T maximumArea2, angleThreshold, shells;
             private readonly int initialPointsCount;
 
             public RefineMeshStep(OutputData<T2> output, Args args, TTransform lt) : this(output,
-                area2Threshold: utils.mul(utils.ConstTBig(2), lt.TransformArea(utils.ConstTBig(args.RefinementThresholdArea))),
-                angleThreshold: args.RefinementThresholdAngle,
-                shells: args.ConcentricShellsParameter)
+                area2Threshold: utils.Cast(utils.mul(utils.Cast(utils.mul(utils.Const(2), utils.Const(args.RefinementThresholdArea))), lt.AreaScalingFactor)),
+                angleThreshold: utils.Const(args.RefinementThresholdAngle),
+                shells: utils.Const(args.ConcentricShellsParameter))
             { }
 
-            public RefineMeshStep(OutputData<T2> output, TBig area2Threshold, float angleThreshold, float shells)
+            public RefineMeshStep(OutputData<T2> output, T area2Threshold, T angleThreshold, T shells)
             {
                 status = output.Status;
                 initialPointsCount = output.Positions.Length;
@@ -1804,7 +1800,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     return;
                 }
 
-                if (!utils.SupportsMeshRefinement) {
+                if (!utils.SupportRefinement())
+                {
                     Debug.LogError("Mesh refinement is not supported for this coordinate type.");
                     status.Value |= Status.ERR;
                     return;
@@ -1888,7 +1885,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 var p1 = outputPositions[triangles[he1]];
                 var p2 = outputPositions[triangles[he2]];
 
-                return utils.le(utils.dot(utils.diff(p0, p2), utils.diff(p1, p2)), utils.ZeroTBig());
+                return utils.le(utils.dot(utils.diff(p0, p2), utils.diff(p1, p2)), utils.Zero());
             }
 
             private void SplitEdge(int he, NativeList<int> heQueue, NativeList<int> tQueue)
@@ -1908,7 +1905,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 }
                 else
                 {
-                    p = utils.PickPointOnConcentricShell(D: shells, e0, e1, i < initialPointsCount);
+                    var alpha = utils.alpha(D: shells, dSquare: utils.Cast(utils.distancesq(e0, e1)), i < initialPointsCount);
+                    p = utils.lerp(e0, e1, alpha);
                 }
 
                 constrainedHalfedges[he] = false;
@@ -2014,7 +2012,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     if (halfedges[he] == -1 || i < j)
                     {
                         var (p0, p1) = (outputPositions[i], outputPositions[j]);
-                        if (utils.le(utils.dot(utils.diff(p0, c.Center), utils.diff(p1, c.Center)), utils.ZeroTBig()))
+                        if (utils.le(utils.dot(utils.diff(p0, c.Center), utils.diff(p1, c.Center)), utils.Zero()))
                         {
                             edges.Add(he);
                         }
@@ -2048,11 +2046,22 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private bool AngleIsTooSmall(int tId, float minimumAngle)
+            private bool AngleIsTooSmall(int tId, T minimumAngle)
             {
                 var (i, j, k) = (triangles[3 * tId + 0], triangles[3 * tId + 1], triangles[3 * tId + 2]);
                 var (pA, pB, pC) = (outputPositions[i], outputPositions[j], outputPositions[k]);
-                return utils.SmallestInnerAngleIsBelowThreshold(pA, pB, pC, minimumAngle);
+
+                var pAB = utils.diff(pB, pA);
+                var pBC = utils.diff(pC, pB);
+                var pCA = utils.diff(pA, pC);
+
+                // TODO: Can be done faster using dot products
+                return utils.anyabslessthan(
+                    a: Angle(pAB, utils.neg(pCA)),
+                    b: Angle(pBC, utils.neg(pAB)),
+                    c: Angle(pCA, utils.neg(pBC)),
+                    v: minimumAngle
+                );
             }
 
             private int UnsafeInsertPointCommon(T2 p, int initTriangle)
@@ -2117,7 +2126,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 }
 
                 var circle = circles[otherId];
-                if (utils.le(utils.distancesq(circle.Center, p), circle.RadiusSq))
+                if (utils.le(utils.Cast(utils.distancesq(circle.Center, p)), circle.RadiusSq))
                 {
                     badTriangles.Add(otherId);
                     trianglesQueue.Enqueue(otherId);
@@ -2420,34 +2429,26 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
         }
 
-        internal static TBig Area2(T2 a, T2 b, T2 c) => utils.abs(Cross(utils.diff(b, a), utils.diff(c, a)));
-        private static TBig Cross(T2 a, T2 b) => utils.diff(utils.mul(utils.X(a), utils.Y(b)), utils.mul(utils.Y(a), utils.X(b)));
-        private static T2 CircumCenter(T2 a, T2 b, T2 c) => utils.CircumCenter(a,b,c);
-        private static TBig CircumRadiusSq(T2 a, T2 b, T2 c) => utils.distancesq(CircumCenter(a, b, c), a);
-        private static (T2, TBig) CalculateCircumCircle(int i, int j, int k, NativeArray<T2> positions)
+        internal static T Angle(T2 a, T2 b) => utils.atan2(Cross(a, b), utils.dot(a, b));
+        internal static T Area2(T2 a, T2 b, T2 c) => utils.abs(Cross(utils.diff(b, a), utils.diff(c, a)));
+        private static T Cross(T2 a, T2 b) => utils.Cast(utils.diff(utils.mul(utils.X(a), utils.Y(b)), utils.mul(utils.Y(a), utils.X(b))));
+        private static TBig CircumRadiusSq(T2 a, T2 b, T2 c) => utils.distancesq(utils.CircumCenter(a, b, c), a);
+        private static (T2, T) CalculateCircumCircle(int i, int j, int k, NativeArray<T2> positions)
         {
             var (pA, pB, pC) = (positions[i], positions[j], positions[k]);
-            return (CircumCenter(pA, pB, pC), CircumRadiusSq(pA, pB, pC));
+            return (utils.CircumCenter(pA, pB, pC), utils.Cast(CircumRadiusSq(pA, pB, pC)));
         }
         private static bool ccw(T2 a, T2 b, T2 c) => utils.greater(
             utils.mul(utils.diff(utils.Y(c), utils.Y(a)), utils.diff(utils.X(b), utils.X(a))),
             utils.mul(utils.diff(utils.Y(b), utils.Y(a)), utils.diff(utils.X(c), utils.X(a)))
         );
-
-        /// <summary>
-        /// True if the edge (a0, a1) intersects the edge (b0, b1).
-        ///
-        /// Colinear edges will not be considered as intersecting.
-        /// Intersections only at the endpoints will not be considered as intersecting.
-        /// </summary>
         internal static bool EdgeEdgeIntersection(T2 a0, T2 a1, T2 b0, T2 b1) => ccw(a0, a1, b0) != ccw(a0, a1, b1) && ccw(b0, b1, a0) != ccw(b0, b1, a1);
         private static int NextHalfedge(int he) => he % 3 == 2 ? he - 2 : he + 1;
-        private static bool InCircle(T2 a, T2 b, T2 c, T2 p) => utils.InCircle(a, b, c, p);
         internal static bool IsConvexQuadrilateral(T2 a, T2 b, T2 c, T2 d) => true
-            && utils.greater(utils.abs(Orient2dFast(a, c, b)), utils.EPSILON_TBIG())
-            && utils.greater(utils.abs(Orient2dFast(a, c, d)), utils.EPSILON_TBIG())
-            && utils.greater(utils.abs(Orient2dFast(b, d, a)), utils.EPSILON_TBIG())
-            && utils.greater(utils.abs(Orient2dFast(b, d, c)), utils.EPSILON_TBIG())
+            && utils.greater(utils.abs(Orient2dFast(a, c, b)), utils.EPSILON())
+            && utils.greater(utils.abs(Orient2dFast(a, c, d)), utils.EPSILON())
+            && utils.greater(utils.abs(Orient2dFast(b, d, a)), utils.EPSILON())
+            && utils.greater(utils.abs(Orient2dFast(b, d, c)), utils.EPSILON())
             && EdgeEdgeIntersection(a, c, b, d)
         ;
         private static TBig Orient2dFast(T2 a, T2 b, T2 c) => utils.diff(
@@ -2455,22 +2456,21 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             utils.mul(utils.diff(utils.X(a), utils.X(c)), utils.diff(utils.Y(b), utils.Y(c)))
         );
         internal static bool PointLineSegmentIntersection(T2 a, T2 b0, T2 b1) => true
-            && utils.le(utils.abs(Orient2dFast(a, b0, b1)), utils.EPSILON_TBIG())
+            && utils.le(utils.abs(Orient2dFast(a, b0, b1)), utils.EPSILON())
             && math.all(utils.ge(a, utils.min(b0, b1)) & utils.le(a, utils.max(b0, b1)));
-        internal static bool PointInsideTriangle(T2 p, T2 a, T2 b, T2 c) => utils.PointInsideTriangle(p, a, b, c);
     }
 
-    internal interface ITransform<TSelf, T, T2, TArea> where T : unmanaged where T2 : unmanaged where TArea : unmanaged
+    internal interface ITransform<TSelf, T, T2> where T : unmanaged where T2 : unmanaged
     {
+        T AreaScalingFactor { get; }
         TSelf Identity { get; }
         TSelf Inverse();
-        TArea TransformArea(TArea area);
         T2 Transform(T2 point);
         TSelf CalculatePCATransformation(NativeArray<T2> positions);
         TSelf CalculateLocalTransformation(NativeArray<T2> positions);
     }
 
-    internal readonly struct AffineTransform32 : ITransform<AffineTransform32, float, float2, float>
+    internal readonly struct AffineTransform32 : ITransform<AffineTransform32, float, float2>
     {
         public readonly AffineTransform32 Identity => new(float2x2.identity, float2.zero);
         public readonly float AreaScalingFactor => math.abs(math.determinant(rotScale));
@@ -2489,7 +2489,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public AffineTransform32 Inverse() => new(math.inverse(rotScale), math.mul(rotScale, -translation));
         public float2 Transform(float2 point) => math.mul(rotScale, point + translation);
-        public float TransformArea(float area) => area * AreaScalingFactor;
 
         public readonly AffineTransform32 CalculatePCATransformation(NativeArray<float2> positions)
         {
@@ -2565,7 +2564,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         private static float2x2 Kron(float2 a, float2 b) => math.float2x2(a * b[0], a * b[1]);
     }
 
-    internal readonly struct AffineTransform64 : ITransform<AffineTransform64, double, double2, double>
+    internal readonly struct AffineTransform64 : ITransform<AffineTransform64, double, double2>
     {
         public readonly AffineTransform64 Identity => new(double2x2.identity, double2.zero);
         public readonly double AreaScalingFactor => math.abs(math.determinant(rotScale));
@@ -2584,7 +2583,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public AffineTransform64 Inverse() => new(math.inverse(rotScale), math.mul(rotScale, -translation));
         public double2 Transform(double2 point) => math.mul(rotScale, point + translation);
-        public double TransformArea(double area) => area * AreaScalingFactor;
 
         public readonly AffineTransform64 CalculatePCATransformation(NativeArray<double2> positions)
         {
@@ -2660,29 +2658,17 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         private static double2x2 Kron(double2 a, double2 b) => math.double2x2(a * b[0], a * b[1]);
     }
 
-    internal readonly struct TranslationInt32 : ITransform<TranslationInt32, int, int2, long>
+    internal readonly struct TranslationInt : ITransform<TranslationInt, int, int2>
     {
-        public readonly TranslationInt32 Identity => new(int2.zero);
-        public readonly long AreaScalingFactor => 1;
-
+        public readonly TranslationInt Identity => new(int2.zero);
+        public readonly int AreaScalingFactor => 1;
         private readonly int2 translation;
-
-        public TranslationInt32(int2 translation) => this.translation = translation;
-        private static TranslationInt32 Translate(int2 offset) => new(offset);
-        public static TranslationInt32 operator *(TranslationInt32 lhs, TranslationInt32 rhs) => new(
-            lhs.translation + rhs.translation
-        );
-
-        public TranslationInt32 Inverse() => new(-translation);
+        public TranslationInt(int2 translation) => this.translation = translation;
+        public TranslationInt Inverse() => new(-translation);
         public int2 Transform(int2 point) => point + translation;
-        public long TransformArea(long area) => area * AreaScalingFactor;
+        public readonly TranslationInt CalculatePCATransformation(NativeArray<int2> positions) => throw new NotImplementedException();
 
-        public readonly TranslationInt32 CalculatePCATransformation(NativeArray<int2> positions)
-        {
-            throw new NotImplementedException("PCA is not implemented for integer coordinates.");
-        }
-
-        public readonly TranslationInt32 CalculateLocalTransformation(NativeArray<int2> positions)
+        public readonly TranslationInt CalculateLocalTransformation(NativeArray<int2> positions)
         {
             int2 min = int.MaxValue, max = int.MinValue, com = 0;
             foreach (var p in positions)
@@ -2692,103 +2678,61 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 com += p;
             }
 
-            com /= positions.Length;
-            // Note: For integer coordinates we only translate points to the origin, but do not scale them.
-            return Translate(-com);
+            return new(-com / positions.Length);
         }
     }
 
     internal interface IUtils<T, T2, TBig> where T : unmanaged where T2 : unmanaged where TBig : unmanaged
     {
-        /// <summary>
-        /// Converts a value to type TBig.
-        ///
-        /// Warning: This may cause loss of precision, and is only safe for (not huge) integer constants.
-        /// </summary>
-        TBig ConstTBig(float v);
-        TBig EPSILON_TBIG();
-        T MaxValue();
+        T Cast(TBig v);
+        T2 CircumCenter(T2 a, T2 b, T2 c);
+        T Const(float v);
+        TBig EPSILON();
+        bool InCircle(T2 a, T2 b, T2 c, T2 p);
+        TBig MaxValue();
         T2 MaxValue2();
-        TBig MaxDistSq();
         T2 MinValue2();
+        bool PointInsideTriangle(T2 p, T2 a, T2 b, T2 c);
+        bool SupportRefinement();
         T X(T2 v);
         T Y(T2 v);
+        T Zero();
         TBig ZeroTBig();
-        bool SupportsMeshRefinement { get; }
-
-        bool PointInsideTriangle(T2 p, T2 a, T2 b, T2 c);
-        bool InCircle(T2 a, T2 b, T2 c, T2 p);
-        T2 CircumCenter(T2 a, T2 b, T2 c);
-
 #pragma warning disable IDE1006
         T abs(T v);
         TBig abs(TBig v);
-        T add(T a, T b);
-        TBig add(TBig a, TBig b);
-
-        /// <summary>
-        /// Picks the closest point to e2 on a set of concentric rings around e1 with radii D*2^k for all integers k.
-        ///
-        /// D is a float for all coordinate types (even when using doubles), because the precision
-        /// of it is not important for the algorithm, and this avoids us having to introduce yet another generic type parameter.
-        /// </summary>
-        /// <param name="initial"/>If true, then e1 and e2 are swapped</param>
-        T2 PickPointOnConcentricShell(float D, T2 e1, T2 e2, bool initial);
-
-        bool SmallestInnerAngleIsBelowThreshold(T2 a, T2 b, T2 c, float angle);
+        T alpha(T D, T dSquare, bool initial);
+        bool anyabslessthan(T a, T b, T c, T v);
+        T atan2(T v, T w);
         T2 avg(T2 a, T2 b);
         T diff(T a, T b);
         TBig diff(TBig a, TBig b);
         T2 diff(T2 a, T2 b);
         TBig distancesq(T2 a, T2 b);
-        TBig dot(T2 a, T2 b);
-        bool eq(T v, T w);
+        T dot(T2 a, T2 b);
         bool2 eq(T2 v, T2 w);
         bool2 ge(T2 a, T2 b);
         bool greater(T a, T b);
         bool greater(TBig a, TBig b);
         int hashkey(T2 p, T2 c, int hashSize);
         bool2 isfinite(T2 v);
-        bool2 le(T2 a, T2 b);
+        bool le(T a, T b);
         bool le(TBig a, TBig b);
-        bool less(T a, T b);
+        bool2 le(T2 a, T2 b);
+        T2 lerp(T2 a, T2 b, T v);
         bool less(TBig a, TBig b);
         T2 max(T2 v, T2 w);
         T2 min(T2 v, T2 w);
         TBig mul(T a, T b);
-        TBig mul(TBig a, TBig b);
+        T2 neg(T2 v);
 #pragma warning restore IDE1006
     }
 
     internal readonly struct FloatUtils : IUtils<float, float2, float>
     {
-        public readonly float ConstTBig(float v) => v;
-        public readonly float EPSILON_TBIG() => math.EPSILON;
-        public readonly float MaxValue() => float.MaxValue;
-        public readonly float2 MaxValue2() => float.MaxValue;
-        public readonly float MaxDistSq() => float.MaxValue;
-        public readonly float2 MinValue2() => float.MinValue;
-        public readonly float X(float2 a) => a.x;
-        public readonly float Y(float2 a) => a.y;
-        public readonly float ZeroTBig() => 0;
-        public readonly bool SupportsMeshRefinement => true;
-
-        static float cross(float2 a, float2 b) => a.x * b.y - a.y * b.x;
-
-        public readonly bool PointInsideTriangle(float2 p, float2 a, float2 b, float2 c) {
-            float3 bar(float2 a, float2 b, float2 c, float2 p) {
-                var (v0, v1, v2) = (b - a, c - a, p - a);
-                var denInv = 1 / cross(v0, v1);
-                var v = denInv * cross(v2, v1);
-                var w = denInv * cross(v0, v2);
-                var u = 1.0f - v - w;
-                return new float3(u, v, w);
-            }
-
-            return math.cmax(-bar(a, b, c, p)) <= 0;;
-        }
-
-        public readonly float2 CircumCenter(float2 a, float2 b, float2 c) {
+        public readonly float Cast(float v) => v;
+        public readonly float2 CircumCenter(float2 a, float2 b, float2 c)
+        {
             var d = b - a;
             var e = c - a;
 
@@ -2797,9 +2741,10 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             var d2 = 0.5f / (d.x * e.y - d.y * e.x);
 
-            return a + d2 * (bl * new float2(e.y, -e.x) + cl * new float2(-d.y, d.x));
+            return a + d2 * (bl * math.float2(e.y, -e.x) + cl * math.float2(-d.y, d.x));
         }
-
+        public readonly float Const(float v) => v;
+        public readonly float EPSILON() => math.EPSILON;
         public readonly bool InCircle(float2 a, float2 b, float2 c, float2 p)
         {
             var dx = a.x - p.x;
@@ -2813,38 +2758,46 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             var bp = ex * ex + ey * ey;
             var cp = fx * fx + fy * fy;
 
-            return dx * (ey * cp - bp * fy) -
-                dy * (ex * cp - bp * fx) +
-                ap * (ex * fy - ey * fx) < 0;
+            return dx * (ey * cp - bp * fy) - dy * (ex * cp - bp * fx) + ap * (ex * fy - ey * fx) < 0;
         }
+        public readonly float MaxValue() => float.MaxValue;
+        public readonly float2 MaxValue2() => float.MaxValue;
+        public readonly float2 MinValue2() => float.MinValue;
+        public readonly bool PointInsideTriangle(float2 p, float2 a, float2 b, float2 c)
+        {
+            static float cross(float2 a, float2 b) => a.x * b.y - a.y * b.x;
+            static float3 bar(float2 a, float2 b, float2 c, float2 p)
+            {
+                var (v0, v1, v2) = (b - a, c - a, p - a);
+                var denInv = 1 / cross(v0, v1);
+                var v = denInv * cross(v2, v1);
+                var w = denInv * cross(v0, v2);
+                var u = 1.0f - v - w;
+                return new(u, v, w);
+            }
 
-        public readonly float2 PickPointOnConcentricShell(float D, float2 e1, float2 e2, bool initial) {
-            var d = math.distance(e1, e2);
+            return math.cmax(-bar(a, b, c, p)) <= 0;
+        }
+        public readonly bool SupportRefinement() => true;
+        public readonly float X(float2 a) => a.x;
+        public readonly float Y(float2 a) => a.y;
+        public readonly float Zero() => 0;
+        public readonly float ZeroTBig() => 0;
+        public readonly float abs(float v) => math.abs(v);
+        public readonly float alpha(float D, float dSquare, bool initial)
+        {
+            var d = math.sqrt(dSquare);
             var k = (int)math.round(math.log2(0.5f * d / D));
             var alpha = D / d * (1 << k);
-            alpha = initial ? alpha : 1 - alpha;
-            return math.lerp(e1, e2, alpha);
+            return initial ? alpha : 1 - alpha;
         }
-
-        public readonly bool SmallestInnerAngleIsBelowThreshold(float2 a, float2 b, float2 c, float angle) {
-            float Cross(float2 a, float2 b) => a.x * b.y - a.y * b.x;
-            float Angle(float2 a, float2 b) => math.atan2(Cross(a, b), math.dot(a, b));
-
-            var pAB = b - a;
-            var pBC = c - b;
-            var pCA = a - c;
-            return math.abs(Angle(pAB, -pCA)) < angle || math.abs(Angle(pBC, -pAB)) < angle || math.abs(Angle(pCA, -pBC)) < angle;
-        }
-
-        public readonly float abs(float v) => math.abs(v);
-        public readonly float add(float a, float b) => a + b;
-
+        public readonly bool anyabslessthan(float a, float b, float c, float v) => math.any(math.abs(math.float3(a, b, c)) < v);
+        public readonly float atan2(float a, float b) => math.atan2(a, b);
         public readonly float2 avg(float2 a, float2 b) => 0.5f * (a + b);
         public readonly float diff(float a, float b) => a - b;
         public readonly float2 diff(float2 a, float2 b) => a - b;
         public readonly float distancesq(float2 a, float2 b) => math.distancesq(a, b);
         public readonly float dot(float2 a, float2 b) => math.dot(a, b);
-        public readonly bool eq(float v, float w) => v == w;
         public readonly bool2 eq(float2 v, float2 w) => v == w;
         public readonly bool2 ge(float2 a, float2 b) => a >= b;
         public readonly bool greater(float a, float b) => a > b;
@@ -2861,41 +2814,19 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly bool2 isfinite(float2 v) => math.isfinite(v);
         public readonly bool le(float a, float b) => a <= b;
         public readonly bool2 le(float2 a, float2 b) => a <= b;
+        public readonly float2 lerp(float2 a, float2 b, float v) => math.lerp(a, b, v);
         public readonly bool less(float a, float b) => a < b;
         public readonly float2 max(float2 v, float2 w) => math.max(v, w);
         public readonly float2 min(float2 v, float2 w) => math.min(v, w);
         public readonly float mul(float a, float b) => a * b;
+        public readonly float2 neg(float2 v) => -v;
     }
 
     internal readonly struct DoubleUtils : IUtils<double, double2, double>
     {
-        public readonly double ConstTBig(float v) => v;
-        public readonly double EPSILON_TBIG() => math.EPSILON_DBL;
-        public readonly double MaxValue() => double.MaxValue;
-        public readonly double2 MaxValue2() => double.MaxValue;
-        public readonly double MaxDistSq() => double.MaxValue;
-        public readonly double2 MinValue2() => double.MinValue;
-        public readonly double X(double2 a) => a.x;
-        public readonly double Y(double2 a) => a.y;
-        public readonly double ZeroTBig() => 0;
-        public readonly bool SupportsMeshRefinement => true;
-
-        static double cross(double2 a, double2 b) => a.x * b.y - a.y * b.x;
-
-        public readonly bool PointInsideTriangle(double2 p, double2 a, double2 b, double2 c) {
-            double3 Barycentric(double2 a, double2 b, double2 c, double2 p) {
-                var (v0, v1, v2) = (b - a, c - a, p - a);
-                var denInv = 1 / cross(v0, v1);
-                var v = denInv * cross(v2, v1);
-                var w = denInv * cross(v0, v2);
-                var u = 1.0f - v - w;
-                return new double3(u, v, w);
-            }
-
-            return math.cmax(-Barycentric(a, b, c, p)) <= 0;;
-        }
-
-        public readonly double2 CircumCenter(double2 a, double2 b, double2 c) {
+        public readonly double Cast(double v) => v;
+        public readonly double2 CircumCenter(double2 a, double2 b, double2 c)
+        {
             var d = b - a;
             var e = c - a;
 
@@ -2904,9 +2835,10 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             var d2 = 0.5 / (d.x * e.y - d.y * e.x);
 
-            return a + d2 * (bl * new double2(e.y, -e.x) + cl * new double2(-d.y, d.x));
+            return a + d2 * (bl * math.double2(e.y, -e.x) + cl * math.double2(-d.y, d.x));
         }
-
+        public readonly double Const(float v) => v;
+        public readonly double EPSILON() => math.EPSILON_DBL;
         public readonly bool InCircle(double2 a, double2 b, double2 c, double2 p)
         {
             var dx = a.x - p.x;
@@ -2920,37 +2852,46 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             var bp = ex * ex + ey * ey;
             var cp = fx * fx + fy * fy;
 
-            return dx * (ey * cp - bp * fy) -
-                dy * (ex * cp - bp * fx) +
-                ap * (ex * fy - ey * fx) < 0;
+            return dx * (ey * cp - bp * fy) - dy * (ex * cp - bp * fx) + ap * (ex * fy - ey * fx) < 0;
         }
+        public readonly double MaxValue() => double.MaxValue;
+        public readonly double2 MaxValue2() => double.MaxValue;
+        public readonly double2 MinValue2() => double.MinValue;
+        public readonly bool PointInsideTriangle(double2 p, double2 a, double2 b, double2 c)
+        {
+            static double cross(double2 a, double2 b) => a.x * b.y - a.y * b.x;
+            static double3 bar(double2 a, double2 b, double2 c, double2 p)
+            {
+                var (v0, v1, v2) = (b - a, c - a, p - a);
+                var denInv = 1 / cross(v0, v1);
+                var v = denInv * cross(v2, v1);
+                var w = denInv * cross(v0, v2);
+                var u = 1 - v - w;
+                return new(u, v, w);
+            }
 
-        public readonly double2 PickPointOnConcentricShell(float D, double2 e1, double2 e2, bool initial) {
-            var d = math.distance(e1, e2);
-            var k = (int)math.round(math.log2(0.5 * d / D));
-            var alpha = D / d * (1 << k);
-            alpha = initial ? alpha : 1 - alpha;
-            return math.lerp(e1, e2, alpha);
+            return math.cmax(-bar(a, b, c, p)) <= 0;
         }
-
-        public readonly bool SmallestInnerAngleIsBelowThreshold(double2 a, double2 b, double2 c, float angle) {
-            double Cross(double2 a, double2 b) => a.x * b.y - a.y * b.x;
-            double Angle(double2 a, double2 b) => math.atan2(Cross(a, b), math.dot(a, b));
-
-            var pAB = b - a;
-            var pBC = c - b;
-            var pCA = a - c;
-            return math.abs(Angle(pAB, -pCA)) < angle || math.abs(Angle(pBC, -pAB)) < angle || math.abs(Angle(pCA, -pBC)) < angle;
-        }
-
+        public readonly bool SupportRefinement() => true;
+        public readonly double X(double2 a) => a.x;
+        public readonly double Y(double2 a) => a.y;
+        public readonly double Zero() => 0;
+        public readonly double ZeroTBig() => 0;
         public readonly double abs(double v) => math.abs(v);
-        public readonly double add(double a, double b) => a + b;
+        public readonly double alpha(double D, double dSquare, bool initial)
+        {
+            var d = math.sqrt(dSquare);
+            var k = (int)math.round(math.log2(0.5f * d / D));
+            var alpha = D / d * (1 << k);
+            return initial ? alpha : 1 - alpha;
+        }
+        public readonly bool anyabslessthan(double a, double b, double c, double v) => math.any(math.abs(math.double3(a, b, c)) < v);
+        public readonly double atan2(double a, double b) => math.atan2(a, b);
         public readonly double2 avg(double2 a, double2 b) => 0.5f * (a + b);
         public readonly double diff(double a, double b) => a - b;
         public readonly double2 diff(double2 a, double2 b) => a - b;
         public readonly double distancesq(double2 a, double2 b) => math.distancesq(a, b);
         public readonly double dot(double2 a, double2 b) => math.dot(a, b);
-        public readonly bool eq(double v, double w) => v == w;
         public readonly bool2 eq(double2 v, double2 w) => v == w;
         public readonly bool2 ge(double2 a, double2 b) => a >= b;
         public readonly bool greater(double a, double b) => a > b;
@@ -2967,60 +2908,31 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly bool2 isfinite(double2 v) => math.isfinite(v);
         public readonly bool le(double a, double b) => a <= b;
         public readonly bool2 le(double2 a, double2 b) => a <= b;
+        public readonly double2 lerp(double2 a, double2 b, double v) => math.lerp(a, b, v);
         public readonly bool less(double a, double b) => a < b;
         public readonly double2 max(double2 v, double2 w) => math.max(v, w);
         public readonly double2 min(double2 v, double2 w) => math.min(v, w);
         public readonly double mul(double a, double b) => a * b;
+        public readonly double2 neg(double2 v) => -v;
     }
 
     internal readonly struct IntUtils : IUtils<int, int2, long>
     {
-        public readonly long ConstTBig(float v) => (long)v;
-        public readonly long EPSILON_TBIG() => 0;
-        public readonly int MaxValue() => int.MaxValue;
-        public readonly int2 MaxValue2() => int.MaxValue;
-        public readonly long MaxDistSq() => long.MaxValue;
-        public readonly int2 MinValue2() => int.MinValue;
-        public readonly int X(int2 a) => a.x;
-        public readonly int Y(int2 a) => a.y;
-        public readonly long ZeroTBig() => 0;
-        public readonly bool SupportsMeshRefinement => false;
-
-        public long cross(int2 a, int2 b) => (long)a.x * (long)b.y - (long)a.y * (long)b.x;
-
-        public readonly bool PointInsideTriangle(int2 p, int2 a, int2 b, int2 c) {
-            var check1 = cross(p - a, b - a);
-            var check2 = cross(p - b, c - b);
-            var check3 = cross(p - c, a - c);
-
-            // Allow for both clockwise and counter-clockwise triangle layouts.
-            // TODO: Is this required, or are all triangles guaranteed to be in one orientation only?
-            return (check1 >= 0 & check2 >= 0 & check3 >= 0) | (check1 <= 0 & check2 <= 0 & check3 <= 0);
-        }
-
-        public readonly int2 CircumCenter(int2 a, int2 b, int2 c) {
+        public readonly int Cast(long v) => (int)v;
+        public readonly int2 CircumCenter(int2 a, int2 b, int2 c)
+        {
             var d = b - a;
             var e = c - a;
 
-            var bl = (long)d.x*d.x + (long)d.y*d.y;
-            var cl = (long)e.x*e.x + (long)e.y*e.y;
+            var bl = (long)d.x * d.x + (long)d.y * d.y;
+            var cl = (long)e.x * e.x + (long)e.y * e.y;
 
-            long div = d.x * e.y - d.y * e.x;
+            var div = (long)d.x * e.y - (long)d.y * e.x;
 
-            // If the triangle is degenerate (just a line), then we should return a point at infinity,
-            // because the circumcenter is not well-defined for this case.
-            // Integers do not have infinites, but we can use the maximum value as a substitute.
-            if (div == 0) return new int2(int.MaxValue, int.MaxValue);
-
-            double d2 = 0.5 / (double)div;
-
-            // Note: Doubles can represent all integers up to 2^53 exactly,
-            // so they can represent all int32 coordinates, and thus it is safe to cast here.
-            var p = (double2)a + d2 * (bl * new double2(e.y, -e.x) + cl * new double2(-d.y, d.x));
-
-            return (int2)math.round(p);
+            return div == 0 ? new(int.MaxValue) : (int2)math.round(a + (0.5 / div) * (bl * math.double2(e.y, -e.x) + cl * math.double2(-d.y, d.x)));
         }
-
+        public readonly int Const(float v) => (int)v;
+        public readonly long EPSILON() => 0;
         public readonly bool InCircle(int2 a, int2 b, int2 c, int2 p)
         {
             var dx = (long)(a.x - p.x);
@@ -3034,39 +2946,32 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             var bp = ex * ex + ey * ey;
             var cp = fx * fx + fy * fy;
 
-            // TODO: This may fail with coordinates that differ by more than approximately 2^20.
-            // When verifying coordinates, we should thus ensure that the bounding box is smaller than 2^20.
-            return dx * (ey * cp - bp * fy) -
-                dy * (ex * cp - bp * fx) +
-                ap * (ex * fy - ey * fx) < 0;
+            return dx * (ey * cp - bp * fy) - dy * (ex * cp - bp * fx) + ap * (ex * fy - ey * fx) < 0;
         }
-
-        public readonly int2 PickPointOnConcentricShell(float D, int2 e1, int2 e2, bool initial) {
-            // Implementation has been removed because it's not used at the moment.
-            // This commit has the implemenation, if it's needed in the future: ad22afe
-            throw new NotImplementedException("PickPointOnConcentricShell is not implemented for integer coordinates.");
+        public readonly long MaxValue() => long.MaxValue;
+        public readonly int2 MaxValue2() => int.MaxValue;
+        public readonly int2 MinValue2() => int.MinValue;
+        public readonly bool PointInsideTriangle(int2 p, int2 a, int2 b, int2 c)
+        {
+            static long cross(int2 a, int2 b) => (long)a.x * b.y - (long)a.y * b.x;
+            return cross(p - a, b - a) >= 0 && cross(p - b, c - b) >= 0 && cross(p - c, a - c) >= 0;
         }
-
-        public readonly bool SmallestInnerAngleIsBelowThreshold(int2 a, int2 b, int2 c, float angle) {
-            // Implementation has been removed because it's not used at the moment.
-            // This commit has the implemenation, if it's needed in the future: ad22afe
-            throw new NotImplementedException("SmallestInnerAngleIsBelowThreshold is not implemented for integer coordinates.");
-        }
-
+        public readonly bool SupportRefinement() => false;
+        public readonly int X(int2 a) => a.x;
+        public readonly int Y(int2 a) => a.y;
+        public readonly int Zero() => 0;
+        public readonly long ZeroTBig() => 0;
         public readonly int abs(int v) => math.abs(v);
         public readonly long abs(long v) => math.abs(v);
-        public readonly int add(int a, int b) => a + b;
-        public readonly long add(long a, long b) => a + b;
-        public readonly int2 avg(int2 a, int2 b) => (a + b)/2;
+        public readonly int alpha(int D, int dSquare, bool initial) => throw new NotImplementedException();
+        public readonly bool anyabslessthan(int a, int b, int c, int v) => throw new NotImplementedException();
+        public readonly int atan2(int a, int b) => throw new NotImplementedException();
+        public readonly int2 avg(int2 a, int2 b) => (a + b) / 2;
         public readonly int diff(int a, int b) => a - b;
         public readonly long diff(long a, long b) => a - b;
         public readonly int2 diff(int2 a, int2 b) => a - b;
-        public readonly long distancesq(int2 a, int2 b) {
-            var d = a - b;
-            return (long)d.x * (long)d.x + (long)d.y * (long)d.y;
-        }
-        public readonly long dot(int2 a, int2 b) => (long)a.x * b.x + (long)a.y * b.y;
-        public readonly bool eq(int v, int w) => v == w;
+        public readonly long distancesq(int2 a, int2 b) => (long)(a - b).x * (a - b).x + (long)(a - b).y * (a - b).y;
+        public readonly int dot(int2 a, int2 b) => throw new NotImplementedException();
         public readonly bool2 eq(int2 v, int2 w) => v == w;
         public readonly bool2 ge(int2 a, int2 b) => a >= b;
         public readonly bool greater(int a, int b) => a > b;
@@ -3077,24 +2982,21 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             static double pseudoAngle(int dx, int dy)
             {
-                var manhattanDist = math.abs(dx) + math.abs(dy);
-                if (manhattanDist == 0) return 0;
-                var p = (double)dx / (double)manhattanDist;
+                var dist = math.abs(dx) + math.abs(dy);
+                if (dist == 0) return 0;
+                var p = (double)dx / dist;
                 return (dy > 0 ? 3 - p : 1 + p) / 4; // [0..1]
             }
         }
-
-        // For purposes of coordinate validation, very large integers are treated as infinite,
-        // since some algorithms may fail with very large coordinates.
-        // TODO: Validate really large coordinates with tests
-        public readonly bool2 isfinite(int2 v) => math.all(math.abs(v) < (1 << 20));
-        public readonly bool2 le(int2 a, int2 b) => a <= b;
+        public readonly bool2 isfinite(int2 v) => true;
+        public readonly bool le(int a, int b) => a <= b;
         public readonly bool le(long a, long b) => a <= b;
-        public readonly bool less(int a, int b) => a < b;
+        public readonly bool2 le(int2 a, int2 b) => a <= b;
+        public readonly int2 lerp(int2 a, int2 b, int v) => throw new NotImplementedException();
         public readonly bool less(long a, long b) => a < b;
         public readonly int2 max(int2 v, int2 w) => math.max(v, w);
         public readonly int2 min(int2 v, int2 w) => math.min(v, w);
         public readonly long mul(int a, int b) => (long)a * b;
-        public readonly long mul(long a, long b) => a * b;
+        public readonly int2 neg(int2 v) => -v;
     }
 }

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2940,7 +2940,6 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             var pAB = b - a;
             var pBC = c - b;
             var pCA = a - c;
-            Debug.Log(math.degrees(Angle(pAB, -pCA)) + " " + math.degrees(Angle(pBC, -pAB)) + " " + math.degrees(Angle(pCA, -pBC)));
             return math.abs(Angle(pAB, -pCA)) < angle || math.abs(Angle(pBC, -pAB)) < angle || math.abs(Angle(pCA, -pBC)) < angle;
         }
 

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2725,7 +2725,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
     /// <typeparam name="T">The raw coordinate type for a single axis. For example float or int.</typeparam>
     /// <typeparam name="T2">The 2D coordinate composed of Ts. For example float2.</typeparam>
     /// <typeparam name="TFloat">A floating point value. Used for angles and fractional values. For example float.</typeparam>
-    /// <typeparam name="TBig">A squared coordinate. Used for squared distances and other products. For example float or long.</typeparam>
+    /// <typeparam name="TBig">A value that may have higher precision compared to T. Used for squared distances and other products.</typeparam>
     internal interface IUtils<T, T2, TFloat, TBig> where T : unmanaged where T2 : unmanaged where TFloat : unmanaged where TBig : unmanaged
     {
         /// <summary>

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -244,14 +244,19 @@ namespace andywiecko.BurstTriangulator
         }
 
         public static void Run(this Triangulator<float2> @this) =>
-            new TriangulationJob<float, float2, AffineTransform32, FloatUtils>(@this).Run();
+            new TriangulationJob<float, float2, float, float, AffineTransform32, FloatUtils>(@this).Run();
         public static JobHandle Schedule(this Triangulator<float2> @this, JobHandle dependencies = default) =>
-            new TriangulationJob<float, float2, AffineTransform32, FloatUtils>(@this).Schedule(dependencies);
+            new TriangulationJob<float, float2, float, float, AffineTransform32, FloatUtils>(@this).Schedule(dependencies);
 
         public static void Run(this Triangulator<double2> @this) =>
-            new TriangulationJob<double, double2, AffineTransform64, DoubleUtils>(@this).Run();
+            new TriangulationJob<double, double2, double, double, AffineTransform64, DoubleUtils>(@this).Run();
         public static JobHandle Schedule(this Triangulator<double2> @this, JobHandle dependencies = default) =>
-            new TriangulationJob<double, double2, AffineTransform64, DoubleUtils>(@this).Schedule(dependencies);
+            new TriangulationJob<double, double2, double, double, AffineTransform64, DoubleUtils>(@this).Schedule(dependencies);
+
+        public static void Run(this Triangulator<int2> @this) =>
+            new TriangulationJob<int, int2, float, long, TranslationInt32, IntUtils>(@this).Run();
+        public static JobHandle Schedule(this Triangulator<int2> @this, JobHandle dependencies = default) =>
+            new TriangulationJob<int, int2, float, long, TranslationInt32, IntUtils>(@this).Schedule(dependencies);
     }
 }
 
@@ -342,28 +347,30 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
     public static class Extensions
     {
-        public static void Triangulate(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
-        public static void PlantHoleSeeds(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
         public static void RefineMesh(this UnsafeTriangulator @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+            new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
 
-        public static void Triangulate(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, AffineTransform32, FloatUtils>().Triangulate(input, output, args, allocator);
-        public static void PlantHoleSeeds(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, AffineTransform32, FloatUtils>().PlantHoleSeeds(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, float, AffineTransform32, FloatUtils>().Triangulate(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, float, AffineTransform32, FloatUtils>().PlantHoleSeeds(input, output, args, allocator);
         public static void RefineMesh(this UnsafeTriangulator<float2> @this, OutputData<float2> output, Allocator allocator, float areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<float, float2, AffineTransform32, FloatUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+            new UnsafeTriangulator<float, float2, float, float, AffineTransform32, FloatUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
 
-        public static void Triangulate(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
-        public static void PlantHoleSeeds(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
         public static void RefineMesh(this UnsafeTriangulator<double2> @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+            new UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
     }
 
     [BurstCompile]
-    internal struct TriangulationJob<T, T2, TTransform, TUtils> : IJob
+    internal struct TriangulationJob<T, T2, TFloat, TDistSq, TTransform, TUtils> : IJob
         where T : unmanaged, IComparable<T>
         where T2 : unmanaged
-        where TTransform : unmanaged, ITransform<TTransform, T, T2>
-        where TUtils : unmanaged, IUtils<T, T2>
+        where TFloat : unmanaged, IComparable<TFloat>
+        where TDistSq : unmanaged, IComparable<TDistSq>
+        where TTransform : unmanaged, ITransform<TTransform, T, T2, TDistSq>
+        where TUtils : unmanaged, IUtils<T, T2, TFloat, TDistSq>
     {
         private NativeArray<T2> inputPositions;
         [NativeDisableContainerSafetyRestriction]
@@ -396,7 +403,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public void Execute()
         {
-            new UnsafeTriangulator<T, T2, TTransform, TUtils>().Triangulate(
+            new UnsafeTriangulator<T, T2, TFloat, TDistSq, TTransform, TUtils>().Triangulate(
                 input: new()
                 {
                     Positions = inputPositions,
@@ -414,11 +421,13 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         }
     }
 
-    internal readonly struct UnsafeTriangulator<T, T2, TTransform, TUtils>
+    internal readonly struct UnsafeTriangulator<T, T2, TFloat, TSquare, TTransform, TUtils>
         where T : unmanaged, IComparable<T>
         where T2 : unmanaged
-        where TTransform : unmanaged, ITransform<TTransform, T, T2>
-        where TUtils : unmanaged, IUtils<T, T2>
+        where TFloat : unmanaged, IComparable<TFloat>
+        where TSquare : unmanaged, IComparable<TSquare>
+        where TTransform : unmanaged, ITransform<TTransform, T, T2, TSquare>
+        where TUtils : unmanaged, IUtils<T, T2, TFloat, TSquare>
     {
         private static readonly TUtils utils = default;
 
@@ -459,13 +468,14 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             new PlantingSeedStep(input, output, args).Execute(allocator, true);
         }
 
-        public void RefineMesh(OutputData<T2> output, Allocator allocator, T area2Threshold, T angleThreshold, T shells, bool constrainBoundary = false)
+        public void RefineMesh(OutputData<T2> output, Allocator allocator, TSquare area2Threshold, TFloat angleThreshold, TFloat shells, bool constrainBoundary = false)
         {
             new RefineMeshStep(output, area2Threshold, angleThreshold, shells).Execute(allocator, refineMesh: true, constrainBoundary);
         }
 
         private void PreProcessInputStep(InputData<T2> input, OutputData<T2> output, Args args, out NativeArray<T2> localHoles, out TTransform lt, Allocator allocator)
         {
+            // TODO: Create markers statically, to reduce overhead
             using var _ = new ProfilerMarker($"{nameof(PreProcessInputStep)}").Auto();
 
             var localPositions = output.Positions;
@@ -696,8 +706,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         {
             private struct DistComparer : IComparer<int>
             {
-                private NativeArray<T> dist;
-                public DistComparer(NativeArray<T> dist) => this.dist = dist;
+                private NativeArray<TSquare> dist;
+                public DistComparer(NativeArray<TSquare> dist) => this.dist = dist;
                 public int Compare(int x, int y) => dist[x].CompareTo(dist[y]);
             }
 
@@ -725,6 +735,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 hullStart = int.MaxValue;
                 c = utils.MaxValue2();
                 verbose = args.Verbose;
+                // TODO: Use a power of two and bitwise AND to improve performance
                 hashSize = (int)math.ceil(math.sqrt(positions.Length));
                 trianglesLen = default;
 
@@ -756,7 +767,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 using var _EDGE_STACK = EDGE_STACK = new(512, allocator);
 
                 var ids = new NativeArray<int>(n, allocator);
-                var dists = new NativeArray<T>(n, allocator);
+                var dists = new NativeArray<TSquare>(n, allocator);
 
                 var min = utils.MaxValue2();
                 var max = utils.MinValue2();
@@ -771,7 +782,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 var center = utils.avg(min, max);
 
                 int i0 = int.MaxValue, i1 = int.MaxValue, i2 = int.MaxValue;
-                var minDistSq = utils.MaxValue();
+                var minDistSq = utils.MaxDistSq();
                 for (int i = 0; i < positions.Length; i++)
                 {
                     var distSq = utils.distancesq(center, positions[i]);
@@ -785,7 +796,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 // Centermost vertex
                 var p0 = positions[i0];
 
-                minDistSq = utils.MaxValue();
+                minDistSq = utils.MaxDistSq();
                 for (int i = 0; i < positions.Length; i++)
                 {
                     if (i == i0) continue;
@@ -800,16 +811,16 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 // Second closest to the center
                 var p1 = positions[i1];
 
-                var minRadius = utils.MaxValue();
+                var minRadiusSq = utils.MaxDistSq();
                 for (int i = 0; i < positions.Length; i++)
                 {
                     if (i == i0 || i == i1) continue;
                     var p = positions[i];
                     var r = CircumRadiusSq(p0, p1, p);
-                    if (utils.less(r, minRadius))
+                    if (utils.less(r, minRadiusSq))
                     {
                         i2 = i;
-                        minRadius = r;
+                        minRadiusSq = r;
                     }
                 }
 
@@ -818,7 +829,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 // are no other vertices inside this triangle.
                 var p2 = positions[i2];
 
-                if (utils.eq(minRadius, utils.MaxValue()))
+                if (minRadiusSq.CompareTo(utils.MaxDistSq()) == 0)
                 {
                     if (verbose)
                     {
@@ -829,7 +840,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 }
 
                 // Swap the order of the vertices if the triangle is not oriented in the right direction
-                if (utils.less(Orient2dFast(p0, p1, p2), utils.Zero()))
+                if (utils.less(Orient2dFast(p0, p1, p2), utils.ZeroSq()))
                 {
                     (i1, i2) = (i2, i1);
                     (p1, p2) = (p2, p1);
@@ -870,9 +881,9 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
                     // Find a visible edge on the convex hull using edge hash
                     var start = 0;
+                    var key = utils.hashkey(p, c, hashSize);
                     for (var j = 0; j < hashSize; j++)
                     {
-                        var key = utils.hashkey(p, c, hashSize);
                         start = hullHash[(key + j) % hashSize];
                         if (start != -1 && start != hullNext[start]) break;
                     }
@@ -881,7 +892,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     var e = start;
                     var q = hullNext[e];
 
-                    while (utils.ge(Orient2dFast(p, positions[e], positions[q]), utils.Zero()))
+                    while (!utils.less(Orient2dFast(p, positions[e], positions[q]), utils.ZeroSq()))
                     {
                         e = q;
                         if (e == start)
@@ -907,7 +918,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     q = hullNext[next];
 
                     // Walk forward through the hull, adding more triangles and flipping recursively
-                    while (utils.less(Orient2dFast(p, positions[next], positions[q]), utils.Zero()))
+                    while (utils.less(Orient2dFast(p, positions[next], positions[q]), utils.ZeroSq()))
                     {
                         t = AddTriangle(next, i, q, hullTri[i], -1, hullTri[next]);
                         hullTri[i] = Legalize(t + 2);
@@ -922,7 +933,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     {
                         q = hullPrev[e];
 
-                        while (utils.less(Orient2dFast(p, positions[q], positions[e]), utils.Zero()))
+                        while (utils.less(Orient2dFast(p, positions[q], positions[e]), utils.ZeroSq()))
                         {
                             t = AddTriangle(q, i, e, -1, hullTri[e], hullTri[q]);
                             Legalize(t + 2);
@@ -1291,7 +1302,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             {
                 var (a0, a1) = (positions[e1.x], positions[e1.y]);
                 var (b0, b1) = (positions[e2.x], positions[e2.y]);
-                return !(math.any(e1.xy == e2.xy | e1.xy == e2.yx)) && UnsafeTriangulator<T, T2, TTransform, TUtils>.EdgeEdgeIntersection(a0, a1, b0, b1);
+                return !(math.any(e1.xy == e2.xy | e1.xy == e2.yx)) && UnsafeTriangulator<T, T2, TFloat, TSquare, TTransform, TUtils>.EdgeEdgeIntersection(a0, a1, b0, b1);
             }
 
             private void CollectIntersections(int2 edge)
@@ -1733,10 +1744,10 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private readonly struct Circle
             {
                 public readonly T2 Center;
-                public readonly T RadiusSq;
+                public readonly TSquare RadiusSq;
                 private readonly T offset;
-                public Circle(T2 center, T radiusSq) => (Center, RadiusSq, offset) = (center, radiusSq, default);
-                public Circle((T2 center, T radiusSq) circle) => (Center, RadiusSq, offset) = (circle.center, circle.radiusSq, default);
+                public Circle(T2 center, TSquare radiusSq) => (Center, RadiusSq, offset) = (center, radiusSq, default);
+                public Circle((T2 center, TSquare radiusSq) circle) => (Center, RadiusSq, offset) = (circle.center, circle.radiusSq, default);
             }
 
             private NativeReference<Status> status;
@@ -1752,16 +1763,18 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private NativeList<int> pathHalfedges;
             private NativeList<bool> visitedTriangles;
 
-            private readonly T maximumArea2, angleThreshold, shells;
+            private readonly TSquare maximumArea2;
+            private readonly TFloat shells;
+            private readonly TFloat angleThreshold;
             private readonly int initialPointsCount;
 
             public RefineMeshStep(OutputData<T2> output, Args args, TTransform lt) : this(output,
-                area2Threshold: utils.mul(utils.mul(utils.Const(2), utils.Const(args.RefinementThresholdArea)), lt.AreaScalingFactor),
-                angleThreshold: utils.Const(args.RefinementThresholdAngle),
-                shells: utils.Const(args.ConcentricShellsParameter))
+                area2Threshold: utils.mul(utils.ConstDistanceSq(2), lt.TransformArea(utils.ConstDistanceSq(args.RefinementThresholdArea))),
+                angleThreshold: utils.ConstFloat(args.RefinementThresholdAngle),
+                shells: utils.ConstFloat(args.ConcentricShellsParameter))
             { }
 
-            public RefineMeshStep(OutputData<T2> output, T area2Threshold, T angleThreshold, T shells)
+            public RefineMeshStep(OutputData<T2> output, TSquare area2Threshold, TFloat angleThreshold, TFloat shells)
             {
                 status = output.Status;
                 initialPointsCount = output.Positions.Length;
@@ -1789,6 +1802,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 {
                     return;
                 }
+
+                if (typeof(T) == typeof(int)) throw new NotSupportedException("Mesh refinement is not supported for integer types.");
 
                 if (constrainBoundary)
                 {
@@ -1868,7 +1883,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                 var p1 = outputPositions[triangles[he1]];
                 var p2 = outputPositions[triangles[he2]];
 
-                return utils.le(utils.dot(utils.diff(p0, p2), utils.diff(p1, p2)), utils.Zero());
+                return utils.le(utils.dot(utils.diff(p0, p2), utils.diff(p1, p2)), utils.ZeroSq());
             }
 
             private void SplitEdge(int he, NativeList<int> heQueue, NativeList<int> tQueue)
@@ -1995,7 +2010,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
                     if (halfedges[he] == -1 || i < j)
                     {
                         var (p0, p1) = (outputPositions[i], outputPositions[j]);
-                        if (utils.le(utils.dot(utils.diff(p0, c.Center), utils.diff(p1, c.Center)), utils.Zero()))
+                        if (utils.le(utils.dot(utils.diff(p0, c.Center), utils.diff(p1, c.Center)), utils.ZeroSq()))
                         {
                             edges.Add(he);
                         }
@@ -2029,7 +2044,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private bool AngleIsTooSmall(int tId, T minimumAngle)
+            private bool AngleIsTooSmall(int tId, TFloat minimumAngle)
             {
                 var (i, j, k) = (triangles[3 * tId + 0], triangles[3 * tId + 1], triangles[3 * tId + 2]);
                 var (pA, pB, pC) = (outputPositions[i], outputPositions[j], outputPositions[k]);
@@ -2412,28 +2427,12 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
         }
 
-        internal static T Angle(T2 a, T2 b) => utils.atan2(Cross(a, b), utils.dot(a, b));
-        internal static T Area2(T2 a, T2 b, T2 c) => utils.abs(Cross(utils.diff(b, a), utils.diff(c, a)));
-        private static T Cross(T2 a, T2 b) => utils.diff(utils.mul(utils.X(a), utils.Y(b)), utils.mul(utils.Y(a), utils.X(b)));
-        private static T2 CircumCenter(T2 a, T2 b, T2 c)
-        {
-            var dx = utils.diff(utils.X(b), utils.X(a));
-            var dy = utils.diff(utils.Y(b), utils.Y(a));
-            var ex = utils.diff(utils.X(c), utils.X(a));
-            var ey = utils.diff(utils.Y(c), utils.Y(a));
-
-            var bl = utils.add(utils.mul(dx, dx), utils.mul(dy, dy));
-            var cl = utils.add(utils.mul(ex, ex), utils.mul(ey, ey));
-
-            var d = utils.div(utils.Const(0.5f), utils.diff(utils.mul(dx, ey), utils.mul(dy, ex)));
-
-            var x = utils.add(utils.X(a), utils.mul(utils.diff(utils.mul(ey, bl), utils.mul(dy, cl)), d));
-            var y = utils.add(utils.Y(a), utils.mul(utils.diff(utils.mul(dx, cl), utils.mul(ex, bl)), d));
-
-            return utils.NewT2(x, y);
-        }
-        private static T CircumRadiusSq(T2 a, T2 b, T2 c) => utils.distancesq(CircumCenter(a, b, c), a);
-        private static (T2, T) CalculateCircumCircle(int i, int j, int k, NativeArray<T2> positions)
+        internal static TFloat Angle(T2 a, T2 b) => utils.atan2(Cross(a, b), utils.dot(a, b));
+        internal static TSquare Area2(T2 a, T2 b, T2 c) => utils.abs(Cross(utils.diff(b, a), utils.diff(c, a)));
+        private static TSquare Cross(T2 a, T2 b) => utils.diff(utils.mul(utils.X(a), utils.Y(b)), utils.mul(utils.Y(a), utils.X(b)));
+        private static T2 CircumCenter(T2 a, T2 b, T2 c) => utils.circumCenter(a,b,c);
+        private static TSquare CircumRadiusSq(T2 a, T2 b, T2 c) => utils.distancesq(CircumCenter(a, b, c), a);
+        private static (T2, TSquare) CalculateCircumCircle(int i, int j, int k, NativeArray<T2> positions)
         {
             var (pA, pB, pC) = (positions[i], positions[j], positions[k]);
             return (CircumCenter(pA, pB, pC), CircumRadiusSq(pA, pB, pC));
@@ -2444,73 +2443,35 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         );
         internal static bool EdgeEdgeIntersection(T2 a0, T2 a1, T2 b0, T2 b1) => ccw(a0, a1, b0) != ccw(a0, a1, b1) && ccw(b0, b1, a0) != ccw(b0, b1, a1);
         private static int NextHalfedge(int he) => he % 3 == 2 ? he - 2 : he + 1;
-        private static bool InCircle(T2 a, T2 b, T2 c, T2 p)
-        {
-            var dx = utils.diff(utils.X(a), utils.X(p));
-            var dy = utils.diff(utils.Y(a), utils.Y(p));
-            var ex = utils.diff(utils.X(b), utils.X(p));
-            var ey = utils.diff(utils.Y(b), utils.Y(p));
-            var fx = utils.diff(utils.X(c), utils.X(p));
-            var fy = utils.diff(utils.Y(c), utils.Y(p));
-
-            var ap = utils.add(utils.mul(dx, dx), utils.mul(dy, dy));
-            var bp = utils.add(utils.mul(ex, ex), utils.mul(ey, ey));
-            var cp = utils.add(utils.mul(fx, fx), utils.mul(fy, fy));
-
-            // dx * (ey * cp - bp * fy) - dy * (ex * cp - bp * fx) + ap * (ex * fy - ey * fx) < 0
-            return utils.less(
-                utils.add(
-                    utils.diff(
-                        utils.mul(dx, utils.diff(utils.mul(ey, cp), utils.mul(bp, fy))),
-                        utils.mul(dy, utils.diff(utils.mul(ex, cp), utils.mul(bp, fx)))
-                    ),
-                    utils.mul(ap, utils.diff(utils.mul(ex, fy), utils.mul(ey, fx)))
-                ),
-                utils.Zero()
-            );
-        }
+        private static bool InCircle(T2 a, T2 b, T2 c, T2 p) => utils.inCircle(a, b, c, p);
         internal static bool IsConvexQuadrilateral(T2 a, T2 b, T2 c, T2 d) => true
-            && utils.greater(utils.abs(Orient2dFast(a, c, b)), utils.EPSILON())
-            && utils.greater(utils.abs(Orient2dFast(a, c, d)), utils.EPSILON())
-            && utils.greater(utils.abs(Orient2dFast(b, d, a)), utils.EPSILON())
-            && utils.greater(utils.abs(Orient2dFast(b, d, c)), utils.EPSILON())
+            && utils.greater(utils.abs(Orient2dFast(a, c, b)), utils.EPSILON_SQ())
+            && utils.greater(utils.abs(Orient2dFast(a, c, d)), utils.EPSILON_SQ())
+            && utils.greater(utils.abs(Orient2dFast(b, d, a)), utils.EPSILON_SQ())
+            && utils.greater(utils.abs(Orient2dFast(b, d, c)), utils.EPSILON_SQ())
             && EdgeEdgeIntersection(a, c, b, d)
         ;
-        private static T Orient2dFast(T2 a, T2 b, T2 c) => utils.diff(
+        private static TSquare Orient2dFast(T2 a, T2 b, T2 c) => utils.diff(
             utils.mul(utils.diff(utils.Y(a), utils.Y(c)), utils.diff(utils.X(b), utils.X(c))),
             utils.mul(utils.diff(utils.X(a), utils.X(c)), utils.diff(utils.Y(b), utils.Y(c)))
         );
         internal static bool PointLineSegmentIntersection(T2 a, T2 b0, T2 b1) => true
-            && utils.le(utils.abs(Orient2dFast(a, b0, b1)), utils.EPSILON())
+            && utils.le(utils.abs(Orient2dFast(a, b0, b1)), utils.EPSILON_SQ())
             && math.all(utils.ge(a, utils.min(b0, b1)) & utils.le(a, utils.max(b0, b1)));
-        private static (T b0, T b1, T b2) bar(T2 a, T2 b, T2 c, T2 p)
-        {
-            var (v0, v1, v2) = (utils.diff(b, a), utils.diff(c, a), utils.diff(p, a));
-            var denInv = utils.div(utils.Const(1), Cross(v0, v1));
-            var v = utils.mul(denInv, Cross(v2, v1));
-            var w = utils.mul(denInv, Cross(v0, v2));
-            var u = utils.diff(utils.diff(utils.Const(1), v), w);
-            return (u, v, w);
-        }
-        internal static bool PointInsideTriangle(T2 p, T2 a, T2 b, T2 c)
-        {
-            var (u, v, w) = bar(a, b, c, p);
-            // math.cmax(-bar(a, b, c, p)) <= 0
-            return utils.le(utils.max(utils.max(utils.neg(u), utils.neg(v)), utils.neg(w)), utils.Zero());
-        }
+        internal static bool PointInsideTriangle(T2 p, T2 a, T2 b, T2 c) => utils.pointInsideTriangle(p, a, b, c);
     }
 
-    internal interface ITransform<TSelf, T, T2> where T : unmanaged where T2 : unmanaged
+    internal interface ITransform<TSelf, T, T2, TArea> where T : unmanaged where T2 : unmanaged where TArea : unmanaged
     {
-        T AreaScalingFactor { get; }
         TSelf Identity { get; }
         TSelf Inverse();
+        TArea TransformArea(TArea area);
         T2 Transform(T2 point);
         TSelf CalculatePCATransformation(NativeArray<T2> positions);
         TSelf CalculateLocalTransformation(NativeArray<T2> positions);
     }
 
-    internal readonly struct AffineTransform32 : ITransform<AffineTransform32, float, float2>
+    internal readonly struct AffineTransform32 : ITransform<AffineTransform32, float, float2, float>
     {
         public readonly AffineTransform32 Identity => new(float2x2.identity, float2.zero);
         public readonly float AreaScalingFactor => math.abs(math.determinant(rotScale));
@@ -2529,6 +2490,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public AffineTransform32 Inverse() => new(math.inverse(rotScale), math.mul(rotScale, -translation));
         public float2 Transform(float2 point) => math.mul(rotScale, point + translation);
+        public float TransformArea(float area) => area * AreaScalingFactor;
 
         public readonly AffineTransform32 CalculatePCATransformation(NativeArray<float2> positions)
         {
@@ -2604,7 +2566,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         private static float2x2 Kron(float2 a, float2 b) => math.float2x2(a * b[0], a * b[1]);
     }
 
-    internal readonly struct AffineTransform64 : ITransform<AffineTransform64, double, double2>
+    internal readonly struct AffineTransform64 : ITransform<AffineTransform64, double, double2, double>
     {
         public readonly AffineTransform64 Identity => new(double2x2.identity, double2.zero);
         public readonly double AreaScalingFactor => math.abs(math.determinant(rotScale));
@@ -2623,6 +2585,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public AffineTransform64 Inverse() => new(math.inverse(rotScale), math.mul(rotScale, -translation));
         public double2 Transform(double2 point) => math.mul(rotScale, point + translation);
+        public double TransformArea(double area) => area * AreaScalingFactor;
 
         public readonly AffineTransform64 CalculatePCATransformation(NativeArray<double2> positions)
         {
@@ -2698,60 +2661,142 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         private static double2x2 Kron(double2 a, double2 b) => math.double2x2(a * b[0], a * b[1]);
     }
 
-    internal interface IUtils<T, T2> where T : unmanaged where T2 : unmanaged
+    internal readonly struct TranslationInt32 : ITransform<TranslationInt32, int, int2, long>
     {
-        T Const(float v);
+        public readonly TranslationInt32 Identity => new(int2.zero);
+        public readonly long AreaScalingFactor => 1;
+
+        private readonly int2 translation;
+
+        public TranslationInt32(int2 translation) => this.translation = translation;
+        private static TranslationInt32 Translate(int2 offset) => new(offset);
+        public static TranslationInt32 operator *(TranslationInt32 lhs, TranslationInt32 rhs) => new(
+            lhs.translation + rhs.translation
+        );
+
+        public TranslationInt32 Inverse() => new(-translation);
+        public int2 Transform(int2 point) => point + translation;
+        public long TransformArea(long area) => area * AreaScalingFactor;
+
+        public readonly TranslationInt32 CalculatePCATransformation(NativeArray<int2> positions)
+        {
+            throw new NotImplementedException("PCA is not implemented for integer coordinates.");
+        }
+
+        public readonly TranslationInt32 CalculateLocalTransformation(NativeArray<int2> positions)
+        {
+            int2 min = int.MaxValue, max = int.MinValue, com = 0;
+            foreach (var p in positions)
+            {
+                min = math.min(p, min);
+                max = math.max(p, max);
+                com += p;
+            }
+
+            com /= positions.Length;
+            // Note: For integer coordinates we only translate points to the origin, but do not scale them.
+            return Translate(-com);
+        }
+    }
+
+    /// <summary>
+    /// Helper interface for math operations that are generic over the coordinate type.
+    /// </summary>
+    /// <typeparam name="T">The raw coordinate type for a single axis. For example float or int.</typeparam>
+    /// <typeparam name="T2">The 2D coordinate composed of Ts. For example float2.</typeparam>
+    /// <typeparam name="TFloat">A floating point value. Used for angles and fractional values. For example float.</typeparam>
+    /// <typeparam name="TSquare">A squared coordinate. Used for squared distances and other products. For example float or long.</typeparam>
+    internal interface IUtils<T, T2, TFloat, TSquare> where T : unmanaged where T2 : unmanaged where TFloat : unmanaged where TSquare : unmanaged
+    {
+        /// <summary>
+        /// Converts a value to type T.
+        ///
+        /// Warning: This may cause loss of precision for very large integers.
+        /// </summary>
+        T Const(int v);
+        /// <summary>
+        /// Converts a value to type TSquare.
+        ///
+        /// Warning: This may cause loss of precision, and is only safe for (not huge) integer constants.
+        /// </summary>
+        TSquare ConstDistanceSq(float v);
+        /// <summary>
+        /// Converts a value to type TFloat.
+        ///
+        /// Warning: This may cause loss of precision, but it always supports fractional values.
+        /// </summary>
+        TFloat ConstFloat(float v);
         T EPSILON();
+        TSquare EPSILON_SQ();
         T MaxValue();
         T2 MaxValue2();
+        TSquare MaxDistSq();
         T2 MinValue2();
         T2 NewT2(T x, T y);
         T X(T2 v);
         T Y(T2 v);
         T Zero();
+        TSquare ZeroSq();
 #pragma warning disable IDE1006
         T abs(T v);
+        TSquare abs(TSquare v);
         T add(T a, T b);
-        T alpha(T D, T dSquare, bool initial);
-        bool anyabslessthan(T a, T b, T c, T v);
-        T atan2(T v, T w);
+        TSquare add(TSquare a, TSquare b);
+        TFloat alpha(TFloat D, TSquare dSquare, bool initial);
+        bool anyabslessthan(TFloat a, TFloat b, TFloat c, TFloat v);
+        // Note: Takes TSquare arguments, even if that's not technically correct for an atan2 function.
+        // It is used like atan2(a*C, b*C) where C is a length of type T.
+        TFloat atan2(TSquare v, TSquare w);
         T2 avg(T2 a, T2 b);
         T diff(T a, T b);
+        TSquare diff(TSquare a, TSquare b);
         T2 diff(T2 a, T2 b);
-        T distancesq(T2 a, T2 b);
+        TSquare distancesq(T2 a, T2 b);
         T div(T a, T b);
-        T dot(T2 a, T2 b);
+        TSquare dot(T2 a, T2 b);
         bool eq(T v, T w);
         bool2 eq(T2 v, T2 w);
         bool ge(T a, T b);
         bool2 ge(T2 a, T2 b);
         bool greater(T a, T b);
+        bool greater(TSquare a, TSquare b);
         int hashkey(T2 p, T2 c, int hashSize);
         bool2 isfinite(T2 v);
         bool le(T a, T b);
         bool2 le(T2 a, T2 b);
-        T2 lerp(T2 a, T2 b, T v);
+        bool le(TSquare a, TSquare b);
+        T2 lerp(T2 a, T2 b, TFloat v);
         bool less(T a, T b);
+        bool less(TSquare a, TSquare b);
         T max(T v, T w);
         T2 max(T2 v, T2 w);
         T2 min(T2 v, T2 w);
-        T mul(T a, T b);
+        TSquare mul(T a, T b);
+        TSquare mul(TSquare a, TSquare b);
         T neg(T v);
         T2 neg(T2 v);
+        bool pointInsideTriangle(T2 p, T2 a, T2 b, T2 c);
+        bool inCircle(T2 a, T2 b, T2 c, T2 p);
+        T2 circumCenter(T2 a, T2 b, T2 c);
 #pragma warning restore IDE1006
     }
 
-    internal readonly struct FloatUtils : IUtils<float, float2>
+    internal readonly struct FloatUtils : IUtils<float, float2, float, float>
     {
-        public readonly float Const(float v) => v;
+        public readonly float Const(int v) => v;
+        public readonly float ConstDistanceSq(float v) => v;
+        public readonly float ConstFloat(float v) => v;
         public readonly float EPSILON() => math.EPSILON;
+        public readonly float EPSILON_SQ() => EPSILON();
         public readonly float MaxValue() => float.MaxValue;
         public readonly float2 MaxValue2() => float.MaxValue;
+        public readonly float MaxDistSq() => float.MaxValue;
         public readonly float2 MinValue2() => float.MinValue;
         public readonly float2 NewT2(float x, float y) => math.float2(x, y);
         public readonly float X(float2 a) => a.x;
         public readonly float Y(float2 a) => a.y;
         public readonly float Zero() => 0;
+        public readonly float ZeroSq() => 0;
         public readonly float abs(float v) => math.abs(v);
         public readonly float add(float a, float b) => a + b;
         public readonly float alpha(float D, float dSquare, bool initial)
@@ -2795,19 +2840,69 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly float mul(float a, float b) => a * b;
         public readonly float neg(float v) => -v;
         public readonly float2 neg(float2 v) => -v;
+
+        static float cross(float2 a, float2 b) => a.x * b.y - a.y * b.x;
+
+        public readonly bool pointInsideTriangle(float2 p, float2 a, float2 b, float2 c) {
+            float3 Barycentric(float2 a, float2 b, float2 c, float2 p) {
+                var (v0, v1, v2) = (b - a, c - a, p - a);
+                var denInv = 1 / cross(v0, v1);
+                var v = denInv * cross(v2, v1);
+                var w = denInv * cross(v0, v2);
+                var u = 1.0f - v - w;
+                return new float3(u, v, w);
+            }
+
+            return math.cmax(-Barycentric(a, b, c, p)) <= 0;;
+        }
+
+        public readonly float2 circumCenter(float2 a, float2 b, float2 c) {
+            var d = b - a;
+            var e = c - a;
+
+            var bl = math.lengthsq(d);
+            var cl = math.lengthsq(e);
+
+            var d2 = 0.5f / (d.x * e.y - d.y * e.x);
+
+            return a + d2 * (bl * new float2(e.y, -e.x) + cl * new float2(-d.y, d.x));
+        }
+
+        public readonly bool inCircle(float2 a, float2 b, float2 c, float2 p)
+        {
+            var dx = a.x - p.x;
+            var dy = a.y - p.y;
+            var ex = b.x - p.x;
+            var ey = b.y - p.y;
+            var fx = c.x - p.x;
+            var fy = c.y - p.y;
+
+            var ap = dx * dx + dy * dy;
+            var bp = ex * ex + ey * ey;
+            var cp = fx * fx + fy * fy;
+
+            return dx * (ey * cp - bp * fy) -
+                dy * (ex * cp - bp * fx) +
+                ap * (ex * fy - ey * fx) < 0;
+        }
     }
 
-    internal readonly struct DoubleUtils : IUtils<double, double2>
+    internal readonly struct DoubleUtils : IUtils<double, double2, double, double>
     {
-        public readonly double Const(float v) => v;
+        public readonly double Const(int v) => v;
+        public readonly double ConstDistanceSq(float v) => v;
+        public readonly double ConstFloat(float v) => v;
         public readonly double EPSILON() => math.EPSILON_DBL;
+        public readonly double EPSILON_SQ() => EPSILON();
         public readonly double MaxValue() => double.MaxValue;
         public readonly double2 MaxValue2() => double.MaxValue;
+        public readonly double MaxDistSq() => double.MaxValue;
         public readonly double2 MinValue2() => double.MinValue;
         public readonly double2 NewT2(double x, double y) => math.double2(x, y);
         public readonly double X(double2 a) => a.x;
         public readonly double Y(double2 a) => a.y;
         public readonly double Zero() => 0;
+        public readonly double ZeroSq() => 0;
         public readonly double abs(double v) => math.abs(v);
         public readonly double add(double a, double b) => a + b;
         public readonly double alpha(double D, double dSquare, bool initial)
@@ -2851,5 +2946,181 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         public readonly double mul(double a, double b) => a * b;
         public readonly double neg(double v) => -v;
         public readonly double2 neg(double2 v) => -v;
+
+        static double cross(double2 a, double2 b) => a.x * b.y - a.y * b.x;
+
+        public readonly bool pointInsideTriangle(double2 p, double2 a, double2 b, double2 c) {
+            double3 Barycentric(double2 a, double2 b, double2 c, double2 p) {
+                var (v0, v1, v2) = (b - a, c - a, p - a);
+                var denInv = 1 / cross(v0, v1);
+                var v = denInv * cross(v2, v1);
+                var w = denInv * cross(v0, v2);
+                var u = 1.0f - v - w;
+                return new double3(u, v, w);
+            }
+
+            return math.cmax(-Barycentric(a, b, c, p)) <= 0;;
+        }
+
+        public readonly double2 circumCenter(double2 a, double2 b, double2 c) {
+            var d = b - a;
+            var e = c - a;
+
+            var bl = math.lengthsq(d);
+            var cl = math.lengthsq(e);
+
+            var d2 = 0.5 / (d.x * e.y - d.y * e.x);
+
+            return a + d2 * (bl * new double2(e.y, -e.x) + cl * new double2(-d.y, d.x));
+        }
+
+        public readonly bool inCircle(double2 a, double2 b, double2 c, double2 p)
+        {
+            var dx = a.x - p.x;
+            var dy = a.y - p.y;
+            var ex = b.x - p.x;
+            var ey = b.y - p.y;
+            var fx = c.x - p.x;
+            var fy = c.y - p.y;
+
+            var ap = dx * dx + dy * dy;
+            var bp = ex * ex + ey * ey;
+            var cp = fx * fx + fy * fy;
+
+            return dx * (ey * cp - bp * fy) -
+                dy * (ex * cp - bp * fx) +
+                ap * (ex * fy - ey * fx) < 0;
+        }
+    }
+
+    internal readonly struct IntUtils : IUtils<int, int2, float, long>
+    {
+        public readonly int Const(int v) => v;
+        public readonly long ConstDistanceSq(float v) => (long)v;
+        public readonly float ConstFloat(float v) => v;
+        public readonly int EPSILON() => 0;
+        public readonly long EPSILON_SQ() => 0;
+        public readonly int MaxValue() => int.MaxValue;
+        public readonly int2 MaxValue2() => int.MaxValue;
+        public readonly long MaxDistSq() => long.MaxValue;
+        public readonly int2 MinValue2() => int.MinValue;
+        public readonly int2 NewT2(int x, int y) => math.int2(x, y);
+        public readonly int X(int2 a) => a.x;
+        public readonly int Y(int2 a) => a.y;
+        public readonly int Zero() => 0;
+        public readonly long ZeroSq() => 0;
+        public readonly int abs(int v) => math.abs(v);
+        public readonly long abs(long v) => math.abs(v);
+        public readonly int add(int a, int b) => a + b;
+        public readonly long add(long a, long b) => a + b;
+        public readonly float alpha(float D, long dSquare, bool initial) {
+            var d = math.sqrt((double)dSquare);
+            var k = (int)math.round(math.log2(0.5 * d / D));
+            var alpha = D / d * (1 << k);
+            return (float)(initial ? alpha : 1 - alpha);
+        }
+        public readonly bool anyabslessthan(float a, float b, float c, float v) => math.any(math.abs(math.double3(a, b, c)) < v);
+        public readonly float atan2(long a, long b) => throw new NotImplementedException();
+        public readonly int2 avg(int2 a, int2 b) => (a + b)/2;
+        public readonly int diff(int a, int b) => a - b;
+        public readonly long diff(long a, long b) => a - b;
+        public readonly int2 diff(int2 a, int2 b) => a - b;
+        public readonly long distancesq(int2 a, int2 b) {
+            var d = a - b;
+            return (long)d.x * (long)d.x + (long)d.y * (long)d.y;
+        }
+        public readonly int div(int a, int b) => a / b;
+        public readonly long dot(int2 a, int2 b) => (long)a.x * b.x + (long)a.y * b.y;
+        public readonly bool eq(int v, int w) => v == w;
+        public readonly bool2 eq(int2 v, int2 w) => v == w;
+        public readonly bool ge(int a, int b) => a >= b;
+        public readonly bool2 ge(int2 a, int2 b) => a >= b;
+        public readonly bool greater(int a, int b) => a > b;
+        public readonly bool greater(long a, long b) => a > b;
+        public readonly int hashkey(int2 p, int2 c, int hashSize)
+        {
+            return (int)math.floor(pseudoAngle(p.x - c.x, p.y - c.y) * hashSize) % hashSize;
+
+            static double pseudoAngle(int dx, int dy)
+            {
+                var manhattanDist = math.abs(dx) + math.abs(dy);
+                if (manhattanDist == 0) return 0;
+                var p = (double)dx / (double)manhattanDist;
+                return (dy > 0 ? 3 - p : 1 + p) / 4; // [0..1]
+            }
+        }
+
+        // For purposes of coordinate validation, very large integers are treated as infinite,
+        // since some algorithms may fail with very large coordinates.
+        // TODO: Validate really large coordinates with tests
+        public readonly bool2 isfinite(int2 v) => math.all(math.abs(v) < (1 << 20));
+        public readonly bool le(int a, int b) => a <= b;
+        public readonly bool2 le(int2 a, int2 b) => a <= b;
+        public readonly bool le(long a, long b) => a <= b;
+        public readonly int2 lerp(int2 a, int2 b, float v) => a + (int2)math.round(new double2(b - a) * v);
+        public readonly bool less(int a, int b) => a < b;
+        public readonly bool less(long a, long b) => a < b;
+        public readonly int max(int v, int w) => math.max(v, w);
+        public readonly int2 max(int2 v, int2 w) => math.max(v, w);
+        public readonly int2 min(int2 v, int2 w) => math.min(v, w);
+        public readonly long mul(int a, int b) => (long)a * b;
+        public readonly long mul(long a, long b) => a * b;
+        public readonly int neg(int v) => -v;
+        public readonly int2 neg(int2 v) => -v;
+
+        public long cross(int2 a, int2 b) => (long)a.x * (long)b.y - (long)a.y * (long)b.x;
+
+        public readonly bool pointInsideTriangle(int2 p, int2 a, int2 b, int2 c) {
+            var check1 = cross(p - a, b - a);
+            var check2 = cross(p - b, c - b);
+            var check3 = cross(p - c, a - c);
+
+            // Allow for both clockwise and counter-clockwise triangle layouts.
+            // TODO: Is this required, or are all triangles guaranteed to be in one orientation only?
+            return (check1 >= 0 & check2 >= 0 & check3 >= 0) | (check1 <= 0 & check2 <= 0 & check3 <= 0);
+        }
+
+        public readonly int2 circumCenter(int2 a, int2 b, int2 c) {
+            var d = b - a;
+            var e = c - a;
+
+            var bl = (long)d.x*d.x + (long)d.y*d.y;
+            var cl = (long)e.x*e.x + (long)e.y*e.y;
+
+            long div = d.x * e.y - d.y * e.x;
+
+            // If the triangle is degenerate (just a line), then we should return a point at infinity,
+            // because the circumcenter is not well-defined for this case.
+            // Integers do not have infinites, but we can use the maximum value as a substitute.
+            if (div == 0) return new int2(int.MaxValue, int.MaxValue);
+
+            double d2 = 0.5 / (double)div;
+
+            // Note: Doubles can represent all integers up to 2^53 exactly,
+            // so they can represent all int32 coordinates, and thus it is safe to cast here.
+            var p = (double2)a + d2 * (bl * new double2(e.y, -e.x) + cl * new double2(-d.y, d.x));
+
+            return (int2)math.round(p);
+        }
+
+        public readonly bool inCircle(int2 a, int2 b, int2 c, int2 p)
+        {
+            var dx = (long)(a.x - p.x);
+            var dy = (long)(a.y - p.y);
+            var ex = (long)(b.x - p.x);
+            var ey = (long)(b.y - p.y);
+            var fx = (long)(c.x - p.x);
+            var fy = (long)(c.y - p.y);
+
+            var ap = dx * dx + dy * dy;
+            var bp = ex * ex + ey * ey;
+            var cp = fx * fx + fy * fy;
+
+            // TODO: This may fail with coordinates that differ by more than approximately 2^20.
+            // When verifying coordinates, we should thus ensure that the bounding box is smaller than 2^20.
+            return dx * (ey * cp - bp * fy) -
+                dy * (ex * cp - bp * fx) +
+                ap * (ex * fy - ey * fx) < 0;
+        }
     }
 }

--- a/Tests/InternalUtilsTests.cs
+++ b/Tests/InternalUtilsTests.cs
@@ -31,8 +31,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             Assert.IsTrue(new FloatUtils().SmallestInnerAngleIsBelowThreshold((float2)a,(float2)b,(float2)c, (float)upper));
             Assert.IsFalse(new FloatUtils().SmallestInnerAngleIsBelowThreshold((float2)a,(float2)b,(float2)c, (float)lower));
 
-            Assert.IsTrue(new IntUtils().SmallestInnerAngleIsBelowThreshold((int2)a,(int2)b,(int2)c, (float)upper));
-            Assert.IsFalse(new IntUtils().SmallestInnerAngleIsBelowThreshold((int2)a,(int2)b,(int2)c, (float)lower));
+            // Integers do not support this right now. Commit ad22afe has an implementation.
+            // Assert.IsTrue(new IntUtils().SmallestInnerAngleIsBelowThreshold((int2)a,(int2)b,(int2)c, (float)upper));
+            // Assert.IsFalse(new IntUtils().SmallestInnerAngleIsBelowThreshold((int2)a,(int2)b,(int2)c, (float)lower));
         }
 
         private static readonly TestCaseData[] area2testData = new TestCaseData[]

--- a/Tests/InternalUtilsTests.cs
+++ b/Tests/InternalUtilsTests.cs
@@ -9,31 +9,19 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
     {
         private static readonly TestCaseData[] angleTestData = new TestCaseData[]
         {
-            new(math.double2(1, 0), math.double2(0, 1), math.double2(0,0), math.PI_DBL / 4) { TestName = "Test case 1 - canonical vectors" },
-            new(math.double2(0, 1), math.double2(1, 0), math.double2(0,0), math.PI_DBL / 4){ TestName = "Test case 2 - canonical vectors (swapped)" },
-            new(math.double2(2, 2), math.double2(3, 2), math.double2(2, 4), math.atan(1.0/2.0)){ TestName = "Test case 3 - no vertex at origin" },
-            // A completely degenerate triangle (all vertices are the same) should also return 0, but the current implementation thinks all 3 inner angles are 180 degrees. Fix in the future.
-            new(math.double2(1, 0), math.double2(1, 0), math.double2(1, 0), 0){ TestName = "Test case 4 - 3 identical vertices", RunState = NUnit.Framework.Interfaces.RunState.Ignored },
-            new(math.double2(1, 0), math.double2(1, 0), math.double2(10, 0), 0){ TestName = "Test case 5 - 2 identical vertices" },
-            new(math.double2(1, 0), math.double2(0, 0), math.double2(-1, 0), 0){ TestName = "Test case 6 - colinear vertices" },
-            new(math.double2(0, 0), math.double2(10, 0), math.double2(5, 73), 2*math.atan(5.0/73.0)){ TestName = "Test case 7 - arbitrary angle" },
+            new(math.double2(1, 0), math.double2(0, 1), math.PI_DBL / 2) { TestName = "Test case 1 - canonical vectors" },
+            new(math.double2(0, 1), math.double2(1, 0), -math.PI_DBL / 2){ TestName = "Test case 2 - canonical vectors (swapped)" },
+            new(math.double2(2, 1), math.double2(-1, 2), math.PI_DBL / 2){ TestName = "Test case 3" },
+            new(math.double2(1, 0), math.double2(1, 0), 0){ TestName = "Test case 4 - zero test" },
+            new(math.double2(1, 0), math.double2(-1, 0), math.PI_DBL){ TestName = "Test case 5 - opposite dir" },
+            new(math.double2(1, 0), math.double2(math.cos(0.5698235), math.sin(0.5698235)), 0.5698235){ TestName = "Test case 6 - arbitrary angle" },
         };
 
         [Test, TestCaseSource(nameof(angleTestData))]
-        public void AngleTest(double2 a, double2 b, double2 c, double expectedSmallestInnerAngle)
+        public void AngleTest(double2 a, double2 b, double expected)
         {
-            var upper = expectedSmallestInnerAngle + 0.001;
-            var lower = expectedSmallestInnerAngle - 0.001;
-
-            Assert.IsTrue(new DoubleUtils().SmallestInnerAngleIsBelowThreshold(a,b,c, (float)upper));
-            Assert.IsFalse(new DoubleUtils().SmallestInnerAngleIsBelowThreshold(a,b,c, (float)lower));
-
-            Assert.IsTrue(new FloatUtils().SmallestInnerAngleIsBelowThreshold((float2)a,(float2)b,(float2)c, (float)upper));
-            Assert.IsFalse(new FloatUtils().SmallestInnerAngleIsBelowThreshold((float2)a,(float2)b,(float2)c, (float)lower));
-
-            // Integers do not support this right now. Commit ad22afe has an implementation.
-            // Assert.IsTrue(new IntUtils().SmallestInnerAngleIsBelowThreshold((int2)a,(int2)b,(int2)c, (float)upper));
-            // Assert.IsFalse(new IntUtils().SmallestInnerAngleIsBelowThreshold((int2)a,(int2)b,(int2)c, (float)lower));
+            var result = UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>.Angle(a, b);
+            Assert.That(result, Is.EqualTo(expected).Within(1e-9));
         }
 
         private static readonly TestCaseData[] area2testData = new TestCaseData[]
@@ -188,6 +176,6 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         }).ToArray();
 
         [Test, TestCaseSource(nameof(pointInsideTriangleTestData))]
-        public bool PointInsideTriangleTest(double2 p, double2 a, double2 b, double2 c) => UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>.PointInsideTriangle(p, a, b, c);
+        public bool PointInsideTriangleTest(double2 p, double2 a, double2 b, double2 c) => default(DoubleUtils).PointInsideTriangle(p, a, b, c);
     }
 }

--- a/Tests/InternalUtilsTests.cs
+++ b/Tests/InternalUtilsTests.cs
@@ -20,7 +20,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test, TestCaseSource(nameof(angleTestData))]
         public void AngleTest(double2 a, double2 b, double expected)
         {
-            var result = UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>.Angle(a, b);
+            var result = UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.Angle(a, b);
             Assert.That(result, Is.EqualTo(expected).Within(1e-9));
         }
 
@@ -47,7 +47,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test, TestCaseSource(nameof(area2testData))]
         public void Area2Test(double2 a, double2 b, double2 c, double expected)
         {
-            var result = UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>.Area2(a, b, c);
+            var result = UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.Area2(a, b, c);
             Assert.That(result, Is.EqualTo(expected).Within(1e-9));
         }
 
@@ -78,7 +78,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                 math.double2(-186.58d, -226d)
             ) { TestName = "Case 4 (gh issue #173)", ExpectedResult = false},
             ///Collinearity is not required to test in package, since it is checked in validation already.
-            ///new (math.double2(0, 0), math.double2(2, 0), math.double2(1, 0), math.double2(3, 0)) 
+            ///new (math.double2(0, 0), math.double2(2, 0), math.double2(1, 0), math.double2(3, 0))
             /// { TestName = "Case 4 (collinear with intersection)", ExpectedResult = true, },
         }.SelectMany(i =>
         {
@@ -98,7 +98,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         ).ToArray();
 
         [Test, TestCaseSource(nameof(edegeVsEdgeTestData))]
-        public bool EdgeEdgeIntersectionTest(double2 a0, double2 a1, double2 b0, double2 b1) => UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>.EdgeEdgeIntersection(a0, a1, b0, b1);
+        public bool EdgeEdgeIntersectionTest(double2 a0, double2 a1, double2 b0, double2 b1) => UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.EdgeEdgeIntersection(a0, a1, b0, b1);
 
         private static readonly TestCaseData[] isConvexQuadrilateralTestData = new TestCaseData[]
         {
@@ -130,7 +130,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         }).ToArray();
 
         [Test, TestCaseSource(nameof(isConvexQuadrilateralTestData))]
-        public bool IsConvexQuadrilateralTest(double2 a, double2 b, double2 c, double2 d) => UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>.IsConvexQuadrilateral(a, b, c, d);
+        public bool IsConvexQuadrilateralTest(double2 a, double2 b, double2 c, double2 d) => UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.IsConvexQuadrilateral(a, b, c, d);
 
         private static readonly TestCaseData[] pointLineSegmentIntersectionTestData = new TestCaseData[]
         {
@@ -154,7 +154,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         }).ToArray();
 
         [Test, TestCaseSource(nameof(pointLineSegmentIntersectionTestData))]
-        public bool PointLineSegmentIntersectionTest(double2 a, double2 b0, double2 b1) => UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>.PointLineSegmentIntersection(a, b0, b1);
+        public bool PointLineSegmentIntersectionTest(double2 a, double2 b0, double2 b1) => UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.PointLineSegmentIntersection(a, b0, b1);
 
         private static readonly TestCaseData[] pointInsideTriangleTestData = new TestCaseData[]
         {
@@ -176,6 +176,6 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         }).ToArray();
 
         [Test, TestCaseSource(nameof(pointInsideTriangleTestData))]
-        public bool PointInsideTriangleTest(double2 p, double2 a, double2 b, double2 c) => UnsafeTriangulator<double, double2, AffineTransform64, DoubleUtils>.PointInsideTriangle(p, a, b, c);
+        public bool PointInsideTriangleTest(double2 p, double2 a, double2 b, double2 c) => UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.PointInsideTriangle(p, a, b, c);
     }
 }

--- a/Tests/InternalUtilsTests.cs
+++ b/Tests/InternalUtilsTests.cs
@@ -12,7 +12,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             new(math.double2(1, 0), math.double2(0, 1), math.double2(0,0), math.PI_DBL / 4) { TestName = "Test case 1 - canonical vectors" },
             new(math.double2(0, 1), math.double2(1, 0), math.double2(0,0), math.PI_DBL / 4){ TestName = "Test case 2 - canonical vectors (swapped)" },
             new(math.double2(2, 2), math.double2(3, 2), math.double2(2, 4), math.atan(1.0/2.0)){ TestName = "Test case 3 - no vertex at origin" },
-            new(math.double2(1, 0), math.double2(1, 0), math.double2(1, 0), 0){ TestName = "Test case 4 - 3 identical vertices" },
+            // A completely degenerate triangle (all vertices are the same) should also return 0, but the current implementation thinks all 3 inner angles are 180 degrees. Fix in the future.
+            new(math.double2(1, 0), math.double2(1, 0), math.double2(1, 0), 0){ TestName = "Test case 4 - 3 identical vertices", RunState = NUnit.Framework.Interfaces.RunState.Ignored },
             new(math.double2(1, 0), math.double2(1, 0), math.double2(10, 0), 0){ TestName = "Test case 5 - 2 identical vertices" },
             new(math.double2(1, 0), math.double2(0, 0), math.double2(-1, 0), 0){ TestName = "Test case 6 - colinear vertices" },
             new(math.double2(0, 0), math.double2(10, 0), math.double2(5, 73), 2*math.atan(5.0/73.0)){ TestName = "Test case 7 - arbitrary angle" },
@@ -21,9 +22,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test, TestCaseSource(nameof(angleTestData))]
         public void AngleTest(double2 a, double2 b, double2 c, double expectedSmallestInnerAngle)
         {
-            var upper = math.cos(expectedSmallestInnerAngle + 0.001);
-            var lower = math.cos(expectedSmallestInnerAngle - 0.001);
-            if (expectedSmallestInnerAngle == 0) lower = 2;
+            var upper = expectedSmallestInnerAngle + 0.001;
+            var lower = expectedSmallestInnerAngle - 0.001;
 
             Assert.IsTrue(new DoubleUtils().SmallestInnerAngleIsBelowThreshold(a,b,c, (float)upper));
             Assert.IsFalse(new DoubleUtils().SmallestInnerAngleIsBelowThreshold(a,b,c, (float)lower));

--- a/Tests/InternalUtilsTests.cs
+++ b/Tests/InternalUtilsTests.cs
@@ -9,19 +9,30 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
     {
         private static readonly TestCaseData[] angleTestData = new TestCaseData[]
         {
-            new(math.double2(1, 0), math.double2(0, 1), math.PI_DBL / 2) { TestName = "Test case 1 - canonical vectors" },
-            new(math.double2(0, 1), math.double2(1, 0), -math.PI_DBL / 2){ TestName = "Test case 2 - canonical vectors (swapped)" },
-            new(math.double2(2, 1), math.double2(-1, 2), math.PI_DBL / 2){ TestName = "Test case 3" },
-            new(math.double2(1, 0), math.double2(1, 0), 0){ TestName = "Test case 4 - zero test" },
-            new(math.double2(1, 0), math.double2(-1, 0), math.PI_DBL){ TestName = "Test case 5 - opposite dir" },
-            new(math.double2(1, 0), math.double2(math.cos(0.5698235), math.sin(0.5698235)), 0.5698235){ TestName = "Test case 6 - arbitrary angle" },
+            new(math.double2(1, 0), math.double2(0, 1), math.double2(0,0), math.PI_DBL / 4) { TestName = "Test case 1 - canonical vectors" },
+            new(math.double2(0, 1), math.double2(1, 0), math.double2(0,0), math.PI_DBL / 4){ TestName = "Test case 2 - canonical vectors (swapped)" },
+            new(math.double2(2, 2), math.double2(3, 2), math.double2(2, 4), math.atan(1.0/2.0)){ TestName = "Test case 3 - no vertex at origin" },
+            new(math.double2(1, 0), math.double2(1, 0), math.double2(1, 0), 0){ TestName = "Test case 4 - 3 identical vertices" },
+            new(math.double2(1, 0), math.double2(1, 0), math.double2(10, 0), 0){ TestName = "Test case 5 - 2 identical vertices" },
+            new(math.double2(1, 0), math.double2(0, 0), math.double2(-1, 0), 0){ TestName = "Test case 6 - colinear vertices" },
+            new(math.double2(0, 0), math.double2(10, 0), math.double2(5, 73), 2*math.atan(5.0/73.0)){ TestName = "Test case 7 - arbitrary angle" },
         };
 
         [Test, TestCaseSource(nameof(angleTestData))]
-        public void AngleTest(double2 a, double2 b, double expected)
+        public void AngleTest(double2 a, double2 b, double2 c, double expectedSmallestInnerAngle)
         {
-            var result = UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.Angle(a, b);
-            Assert.That(result, Is.EqualTo(expected).Within(1e-9));
+            var upper = math.cos(expectedSmallestInnerAngle + 0.001);
+            var lower = math.cos(expectedSmallestInnerAngle - 0.001);
+            if (expectedSmallestInnerAngle == 0) lower = 2;
+
+            Assert.IsTrue(new DoubleUtils().SmallestInnerAngleIsBelowThreshold(a,b,c, (float)upper));
+            Assert.IsFalse(new DoubleUtils().SmallestInnerAngleIsBelowThreshold(a,b,c, (float)lower));
+
+            Assert.IsTrue(new FloatUtils().SmallestInnerAngleIsBelowThreshold((float2)a,(float2)b,(float2)c, (float)upper));
+            Assert.IsFalse(new FloatUtils().SmallestInnerAngleIsBelowThreshold((float2)a,(float2)b,(float2)c, (float)lower));
+
+            Assert.IsTrue(new IntUtils().SmallestInnerAngleIsBelowThreshold((int2)a,(int2)b,(int2)c, (float)upper));
+            Assert.IsFalse(new IntUtils().SmallestInnerAngleIsBelowThreshold((int2)a,(int2)b,(int2)c, (float)lower));
         }
 
         private static readonly TestCaseData[] area2testData = new TestCaseData[]
@@ -47,7 +58,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test, TestCaseSource(nameof(area2testData))]
         public void Area2Test(double2 a, double2 b, double2 c, double expected)
         {
-            var result = UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.Area2(a, b, c);
+            var result = UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>.Area2(a, b, c);
             Assert.That(result, Is.EqualTo(expected).Within(1e-9));
         }
 
@@ -98,7 +109,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         ).ToArray();
 
         [Test, TestCaseSource(nameof(edegeVsEdgeTestData))]
-        public bool EdgeEdgeIntersectionTest(double2 a0, double2 a1, double2 b0, double2 b1) => UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.EdgeEdgeIntersection(a0, a1, b0, b1);
+        public bool EdgeEdgeIntersectionTest(double2 a0, double2 a1, double2 b0, double2 b1) => UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>.EdgeEdgeIntersection(a0, a1, b0, b1);
 
         private static readonly TestCaseData[] isConvexQuadrilateralTestData = new TestCaseData[]
         {
@@ -130,7 +141,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         }).ToArray();
 
         [Test, TestCaseSource(nameof(isConvexQuadrilateralTestData))]
-        public bool IsConvexQuadrilateralTest(double2 a, double2 b, double2 c, double2 d) => UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.IsConvexQuadrilateral(a, b, c, d);
+        public bool IsConvexQuadrilateralTest(double2 a, double2 b, double2 c, double2 d) => UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>.IsConvexQuadrilateral(a, b, c, d);
 
         private static readonly TestCaseData[] pointLineSegmentIntersectionTestData = new TestCaseData[]
         {
@@ -154,7 +165,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         }).ToArray();
 
         [Test, TestCaseSource(nameof(pointLineSegmentIntersectionTestData))]
-        public bool PointLineSegmentIntersectionTest(double2 a, double2 b0, double2 b1) => UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.PointLineSegmentIntersection(a, b0, b1);
+        public bool PointLineSegmentIntersectionTest(double2 a, double2 b0, double2 b1) => UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>.PointLineSegmentIntersection(a, b0, b1);
 
         private static readonly TestCaseData[] pointInsideTriangleTestData = new TestCaseData[]
         {
@@ -176,6 +187,6 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         }).ToArray();
 
         [Test, TestCaseSource(nameof(pointInsideTriangleTestData))]
-        public bool PointInsideTriangleTest(double2 p, double2 a, double2 b, double2 c) => UnsafeTriangulator<double, double2, double, double, AffineTransform64, DoubleUtils>.PointInsideTriangle(p, a, b, c);
+        public bool PointInsideTriangleTest(double2 p, double2 a, double2 b, double2 c) => UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>.PointInsideTriangle(p, a, b, c);
     }
 }

--- a/Tests/TestUtils.cs
+++ b/Tests/TestUtils.cs
@@ -91,6 +91,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             Extensions.Schedule((dynamic)triangulator, dependencies);
         public static T[] DynamicCast<T>(this IEnumerable<float2> data) where T : unmanaged =>
             data.Select(i => (T)(dynamic)i).ToArray();
+        public static IEnumerable<float2> Scale(this IEnumerable<float2> data, float s, bool predicate) => data.Select(i => (predicate ? s : 1f) * i);
         public static T[] DynamicCast<T>(this IEnumerable<double2> data) where T : unmanaged =>
             data.Select(i => (T)(dynamic)i).ToArray();
         public static IEqualityComparer<T> Comparer<T>(float epsilon = 0.0001f) => default(T) switch

--- a/Tests/TriangulatorEditorTests.cs
+++ b/Tests/TriangulatorEditorTests.cs
@@ -1,11 +1,9 @@
 using NUnit.Framework;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
-using UnityEngine.TestTools;
 
 namespace andywiecko.BurstTriangulator.Editor.Tests
 {
@@ -67,24 +65,6 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
 
             if (holes.IsCreated) { holes.Dispose(); }
             if (constraints.IsCreated) { constraints.Dispose(); }
-        }
-
-        [Test]
-        public void MeshRefinementIntSupportTest()
-        {
-            using var positions = new NativeArray<int2>(LakeSuperior.Points.Select(i => (int2)(i * 1000)).ToArray(), Allocator.Persistent);
-            var holes = new NativeArray<int2>(LakeSuperior.Holes.Select(i => (int2)(i * 1000)).ToArray(), Allocator.Persistent);
-            var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
-
-            using var impl = new Triangulator<int2>(Allocator.Persistent)
-            {
-                Input = { Positions = positions, ConstraintEdges = constraints, HoleSeeds = holes },
-                Settings = { AutoHolesAndBoundary = false, RefineMesh = true, RestoreBoundary = true, Preprocessor = Preprocessor.None }
-            };
-
-            impl.Run();
-
-            LogAssert.Expect(UnityEngine.LogType.Error, new Regex("Mesh refinement is not supported for this coordinate type.*"));
         }
 
         [Test]

--- a/Tests/TriangulatorGenericsEditorTests.cs
+++ b/Tests/TriangulatorGenericsEditorTests.cs
@@ -10,6 +10,27 @@ using UnityEngine.TestTools;
 
 namespace andywiecko.BurstTriangulator.Editor.Tests
 {
+    public class TriangulatorGenericsEditorTests
+    {
+        [Test]
+        public void MeshRefinementIntSupportTest()
+        {
+            using var positions = new NativeArray<int2>(LakeSuperior.Points.Select(i => (int2)(i * 1000)).ToArray(), Allocator.Persistent);
+            var holes = new NativeArray<int2>(LakeSuperior.Holes.Select(i => (int2)(i * 1000)).ToArray(), Allocator.Persistent);
+            var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
+
+            using var triangulator = new Triangulator<int2>(Allocator.Persistent)
+            {
+                Input = { Positions = positions, ConstraintEdges = constraints, HoleSeeds = holes },
+                Settings = { AutoHolesAndBoundary = false, RefineMesh = true, RestoreBoundary = true, Preprocessor = Preprocessor.None }
+            };
+
+            triangulator.Run();
+
+            LogAssert.Expect(UnityEngine.LogType.Error, new Regex("Mesh refinement is not supported for this coordinate type.*"));
+        }
+    }
+
     [TestFixture(typeof(float2))]
     [TestFixture(typeof(double2))]
     [TestFixture(typeof(int2))]
@@ -283,7 +304,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void DelaunayTriangulationWithRefinementTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             ///  3 ------- 2
             ///  |         |
@@ -717,7 +741,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test, TestCaseSource(nameof(constraintDelaunayTriangulationWithRefinementTestData))]
         public void ConstraintDelaunayTriangulationWithRefinementTest((float2[] managedPositions, int[] constraints, float2[] insertedPoints, int[] triangles) input)
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             using var positions = new NativeArray<T>(input.managedPositions.DynamicCast<T>(), Allocator.Persistent);
             using var constraintEdges = new NativeArray<int>(input.constraints, Allocator.Persistent);
@@ -810,7 +837,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void BoundaryReconstructionWithRefinementTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             // 4.             .2
             // | '.         .' |
@@ -1077,7 +1107,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void TriangulationWithHolesWithRefinementTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             //   * --------------------- *
             //   |                       |
@@ -1249,7 +1282,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void DeferredArraySupportTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             using var positions = new NativeList<T>(64, Allocator.Persistent);
             using var constraints = new NativeList<int>(64, Allocator.Persistent);
@@ -1505,7 +1541,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void PCATransformationPositionsConservationTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("PCA transformation is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("PCA transformation is not supported for int2.");
+            }
 
             using var positions = new NativeArray<T>(new[]
             {
@@ -1536,7 +1575,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void PCATransformationPositionsConservationWithRefinementTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("PCA transformation is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("PCA transformation is not supported for int2.");
+            }
 
             using var positions = new NativeArray<T>(new[]
             {
@@ -1569,7 +1611,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void PCATransformationWithHolesTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("PCA transformation is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("PCA transformation is not supported for int2.");
+            }
 
             //   3 --------------------- 2
             //   |                       |
@@ -1632,7 +1677,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void CleanupPointsWithHolesTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             using var positions = new NativeArray<T>(new float2[]
             {
@@ -1670,7 +1718,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void RefinementWithoutConstraintsTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             var n = 20;
 
@@ -1718,7 +1769,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test(Description = "Checks if triangulator passes for `very` accute angle input")]
         public void AccuteInputAngleTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             using var positions = new NativeArray<T>(new[] {
                 math.float2(0, 0),
@@ -1758,7 +1812,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void GenericCase1Test()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             using var positions = new NativeArray<T>(new[] {
                 math.float2(0, 0),
@@ -1897,7 +1954,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void HalfedgesForTriangulationWithRefinementTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
             using var positions = new NativeArray<T>(new float2[]
             {

--- a/Tests/TriangulatorGenericsEditorTests.cs
+++ b/Tests/TriangulatorGenericsEditorTests.cs
@@ -12,6 +12,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
 {
     [TestFixture(typeof(float2))]
     [TestFixture(typeof(double2))]
+    [TestFixture(typeof(int2))]
     public class TriangulatorGenericsEditorTests<T> where T : unmanaged
     {
         [Test]
@@ -91,6 +92,11 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test, TestCaseSource(nameof(validateInputPositionsTestData))]
         public void ValidateInputPositionsTest(float2[] managedPositions)
         {
+            if (typeof(T) == typeof(int2) && managedPositions.Any(p => !math.all(math.isfinite(p))))
+            {
+                Assert.Ignore("Integer coordinates cannot be infinite or NaN.");
+            }
+
             using var positions = new NativeArray<T>(managedPositions.DynamicCast<T>(), Allocator.Persistent);
             using var triangulator = new Triangulator<T>(capacity: 1024, Allocator.Persistent)
             {
@@ -110,6 +116,11 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test, TestCaseSource(nameof(validateInputPositionsNoVerboseTestData))]
         public void ValidateInputPositionsNoVerboseTest(float2[] managedPositions)
         {
+            if (typeof(T) == typeof(int2) && managedPositions.Any(p => !math.all(math.isfinite(p))))
+            {
+                Assert.Ignore("Integer coordinates cannot be infinite or NaN.");
+            }
+
             using var positions = new NativeArray<T>(managedPositions.DynamicCast<T>(), Allocator.Persistent);
             using var triangulator = new Triangulator<T>(capacity: 1024, Allocator.Persistent)
             {
@@ -158,10 +169,10 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                 new[]
                 {
                     math.float2(0, 0),
-                    math.float2(0.5f, 0),
                     math.float2(1, 0),
-                    math.float2(1, 1),
-                    math.float2(0, 1),
+                    math.float2(2, 0),
+                    math.float2(2, 2),
+                    math.float2(0, 2),
                 },
                 new[]{ 0, 2 }
             ) { TestName = "Test Case 4 (edge collinear with other point)" },
@@ -272,6 +283,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void DelaunayTriangulationWithRefinementTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             ///  3 ------- 2
             ///  |         |
             ///  |         |
@@ -434,6 +447,39 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                     11, 10, 2,
                 }
                 ){ TestName = "Test case 3" },
+            //   4   5   6   7
+            //   *   *   *   *
+            //
+            //
+            //
+            //
+            // *   *   *   *
+            // 0   1   2   3
+            new(new[]
+            {
+                math.float2(0, 0),
+                math.float2(2, 0),
+                math.float2(4, 0),
+                math.float2(6, 0),
+                math.float2(1, 3),
+                math.float2(3, 3),
+                math.float2(5, 3),
+                math.float2(7, 3),
+            },
+            new int[] {},
+            new[]
+                {
+                    0, 4, 1,
+                    1, 4, 5,
+                    1, 5, 2,
+                    2, 5, 6,
+                    2, 6, 3,
+                    3, 6, 7,
+                }
+            )
+            {
+                TestName = "Test case 4 (no constraints)",
+            },
             // 4   5   6   7
             // *   *   *  ,*
             //         ..;
@@ -671,6 +717,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test, TestCaseSource(nameof(constraintDelaunayTriangulationWithRefinementTestData))]
         public void ConstraintDelaunayTriangulationWithRefinementTest((float2[] managedPositions, int[] constraints, float2[] insertedPoints, int[] triangles) input)
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             using var positions = new NativeArray<T>(input.managedPositions.DynamicCast<T>(), Allocator.Persistent);
             using var constraintEdges = new NativeArray<int>(input.constraints, Allocator.Persistent);
             using var triangulator = new Triangulator<T>(capacity: 1024, Allocator.Persistent)
@@ -698,22 +746,22 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void BoundaryReconstructionWithoutRefinementTest()
         {
-            // 7 ----- 6       3 ----- 2
-            // |       |       |       |
-            // |       |       |       |
-            // |       5 ----- 4       |
-            // |                       |
-            // |                       |
-            // 0 --------------------- 1
+            // 7 -------------- 6       3 ----- 2
+            // |                |       |       |
+            // |                |       |       |
+            // |                5 ----- 4       |
+            // |                                |
+            // |                                |
+            // 0 ------------------------------ 1
             var managedPositions = new[]
             {
                 math.float2(0, 0),
-                math.float2(3, 0),
+                math.float2(4, 0),
+                math.float2(4, 2),
                 math.float2(3, 2),
-                math.float2(2, 2),
+                math.float2(3, 1),
                 math.float2(2, 1),
-                math.float2(1, 1),
-                math.float2(1, 2),
+                math.float2(2, 2),
                 math.float2(0, 2),
             };
 
@@ -762,6 +810,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void BoundaryReconstructionWithRefinementTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             // 4.             .2
             // | '.         .' |
             // |   '.     .'   |
@@ -822,28 +872,28 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
 
         private static readonly TestCaseData[] triangulationWithHolesWithoutRefinementTestData =
         {
-            //   * --------------------- *
+            //   3 --------------------- 2
             //   |                       |
             //   |                       |
-            //   |       * ----- *       |
+            //   |       7 ----- 6       |
             //   |       |   X   |       |
             //   |       |       |       |
-            //   |       * ----- *       |
+            //   |       4 ----- 5       |
             //   |                       |
             //   |                       |
-            //   * --------------------- *
+            //   0 --------------------- 1
             new(
                 new[]
                 {
                     math.float2(0, 0),
-                    math.float2(3, 0),
-                    math.float2(3, 3),
-                    math.float2(0, 3),
+                    math.float2(6, 0),
+                    math.float2(6, 6),
+                    math.float2(0, 6),
 
-                    math.float2(1, 1),
-                    math.float2(2, 1),
                     math.float2(2, 2),
-                    math.float2(1, 2),
+                    math.float2(4, 2),
+                    math.float2(4, 4),
+                    math.float2(2, 4),
                 },
                 new[]
                 {
@@ -857,7 +907,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                     6, 7,
                     7, 4
                 },
-                new[] { (float2)1.5f },
+                new[] { (float2)3f },
                 new[]
                 {
                     0, 3, 7,
@@ -874,14 +924,14 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                 new[]
                 {
                     math.float2(0, 0),
-                    math.float2(3, 0),
-                    math.float2(3, 3),
-                    math.float2(0, 3),
+                    math.float2(6, 0),
+                    math.float2(6, 6),
+                    math.float2(0, 6),
 
-                    math.float2(1, 1),
-                    math.float2(2, 1),
                     math.float2(2, 2),
-                    math.float2(1, 2),
+                    math.float2(4, 2),
+                    math.float2(4, 4),
+                    math.float2(2, 4),
                 },
                 new[]
                 {
@@ -895,7 +945,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                     6, 7,
                     7, 4
                 },
-                new[] { (float2)1.5f, (float2)1.5f },
+                new[] { (float2)3f, (float2)3f },
                 new[]
                 {
                     0, 3, 7,
@@ -949,17 +999,27 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                 }
             ){ TestName = "Test Case 3 (hole out of range)" },
             new(
+                //   3 --------------------- 2
+                //   |                       |
+                //   |                       |
+                //   |                       |
+                //   |    7 ----- 6          |
+                //   |    |     X |          |
+                //   |    | X     |          |
+                //   |    4 ----- 5          |
+                //   |                       |
+                //   0 --------------------- 1
                 new[]
                 {
                     math.float2(0, 0),
-                    math.float2(3, 0),
-                    math.float2(3, 3),
-                    math.float2(0, 3),
+                    math.float2(9, 0),
+                    math.float2(9, 9),
+                    math.float2(0, 9),
 
-                    math.float2(1, 1),
-                    math.float2(2, 1),
                     math.float2(2, 2),
-                    math.float2(1, 2),
+                    math.float2(5, 2),
+                    math.float2(5, 5),
+                    math.float2(2, 5),
                 },
                 new[]
                 {
@@ -973,17 +1033,17 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                     6, 7,
                     7, 4
                 },
-                new[] { math.float2(1.5f + 0.25f, 1.5f), math.float2(1.5f - 0.25f, 1.5f) },
+                new[] { math.float2(3, 3), math.float2(4, 4) },
                 new[]
                 {
                     0, 3, 7,
-                    4, 0, 7,
-                    5, 0, 4,
-                    5, 1, 0,
-                    6, 1, 5,
-                    6, 2, 1,
-                    7, 2, 6,
-                    7, 3, 2,
+                    0, 4, 5,
+                    0, 5, 1,
+                    0, 7, 4,
+                    1, 5, 6,
+                    1, 6, 2,
+                    2, 6, 3,
+                    3, 6, 7,
                 }
             ){ TestName = "Test Case 4 (hole seeds in the same area)" },
         };
@@ -1017,6 +1077,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void TriangulationWithHolesWithRefinementTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             //   * --------------------- *
             //   |                       |
             //   |                       |
@@ -1187,6 +1249,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void DeferredArraySupportTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             using var positions = new NativeList<T>(64, Allocator.Persistent);
             using var constraints = new NativeList<int>(64, Allocator.Persistent);
             using var holes = new NativeList<T>(64, Allocator.Persistent);
@@ -1347,6 +1411,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void LocalTransformationWithHolesTest()
         {
+            var scaleFactor = typeof(T) == typeof(int2) ? 1000 : 0.1f;
+
             var n = 12;
             var innerCircle = Enumerable
                 .Range(0, n)
@@ -1363,7 +1429,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                 .ToArray();
 
             var managedPositions = new float2[] { 0 }.Concat(outerCircle).Concat(innerCircle).ToArray();
-            managedPositions = managedPositions.Select(x => 0.1f * x + 5f).ToArray();
+            managedPositions = managedPositions.Select(x => scaleFactor * x + 5f).ToArray();
 
             var constraints = Enumerable
                 .Range(1, n - 1)
@@ -1439,6 +1505,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void PCATransformationPositionsConservationTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("PCA transformation is not supported for integer types.");
+
             using var positions = new NativeArray<T>(new[]
             {
                 math.float2(1, 1),
@@ -1468,6 +1536,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void PCATransformationPositionsConservationWithRefinementTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("PCA transformation is not supported for integer types.");
+
             using var positions = new NativeArray<T>(new[]
             {
                 math.float2(1, 1),
@@ -1499,19 +1569,21 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void PCATransformationWithHolesTest()
         {
-            //   * --------------------- *
+            if (typeof(T) == typeof(int2)) Assert.Ignore("PCA transformation is not supported for integer types.");
+
+            //   3 --------------------- 2
             //   |                       |
             //   |                       |
-            //   |       * ----- *       |
-            //   |       |   X   |       |
-            //   |       |       |       |
-            //   |       * ----- *       |
             //   |                       |
+            //   |     7 ----- 6         |
+            //   |     |   X   |         |
+            //   |     |       |         |
+            //   |     4 ----- 5         |
             //   |                       |
-            //   * --------------------- *
+            //   0 --------------------- 1
             using var positions = new NativeArray<T>(new[]
             {
-                math.float2(0, 0), math.float2(3, 0), math.float2(3, 3), math.float2(0, 3),
+                math.float2(0, 0), math.float2(6, 0), math.float2(6, 6), math.float2(0, 6),
                 math.float2(1, 1), math.float2(2, 1), math.float2(2, 2), math.float2(1, 2),
             }.DynamicCast<T>(), Allocator.Persistent);
 
@@ -1546,13 +1618,13 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             var expected = new[]
             {
                 0, 3, 7,
-                4, 0, 7,
-                5, 0, 4,
-                5, 1, 0,
-                6, 1, 5,
-                6, 2, 1,
-                7, 2, 6,
-                7, 3, 2,
+                0, 4, 5,
+                0, 5, 1,
+                0, 7, 4,
+                1, 5, 6,
+                1, 6, 2,
+                2, 6, 3,
+                3, 6, 7,
             };
             Assert.That(triangulator.Output.Triangles.AsArray(), Is.EqualTo(expected).Using(TrianglesComparer.Instance));
         }
@@ -1560,6 +1632,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void CleanupPointsWithHolesTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             using var positions = new NativeArray<T>(new float2[]
             {
                 new(0, 0),
@@ -1596,6 +1670,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void RefinementWithoutConstraintsTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             var n = 20;
 
             using var positions = new NativeArray<T>(Enumerable
@@ -1642,10 +1718,12 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test(Description = "Checks if triangulator passes for `very` accute angle input")]
         public void AccuteInputAngleTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             using var positions = new NativeArray<T>(new[] {
                 math.float2(0, 0),
-                math.float2(1, 0),
-                math.float2(1, .1f),
+                math.float2(10, 0),
+                math.float2(10, 1f),
             }.DynamicCast<T>(), Allocator.Persistent);
             using var constraints = new NativeArray<int>(new[] {
                 0, 1,
@@ -1661,7 +1739,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
                     RestoreBoundary = true,
                     RefinementThresholds =
                     {
-                        Area = 1f,
+                        Area = 100f,
                         Angle = math.radians(20f),
                     }
                 },
@@ -1680,6 +1758,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void GenericCase1Test()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             using var positions = new NativeArray<T>(new[] {
                 math.float2(0, 0),
                 math.float2(3, 0),
@@ -1783,18 +1863,18 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             using var positions = new NativeArray<T>(new float2[]
             {
                 math.float2(0, 0),
-                math.float2(4, 0),
-                math.float2(2, 4),
-                math.float2(2, 2),
-                math.float2(1.5f, 1),
-                math.float2(2.5f, 1),
+                math.float2(8, 0),
+                math.float2(4, 8),
+                math.float2(4, 4),
+                math.float2(3, 2),
+                math.float2(5, 2),
             }.DynamicCast<T>(), Allocator.Persistent);
             using var constraints = new NativeArray<int>(new[]
             {
                 0, 1, 1, 2, 2, 0,
                 3, 4, 4, 5, 5, 3,
             }, Allocator.Persistent);
-            using var holes = new NativeArray<T>(new[] { math.float2(2, 1.5f) }.DynamicCast<T>(), Allocator.Persistent);
+            using var holes = new NativeArray<T>(new[] { math.float2(4, 3) }.DynamicCast<T>(), Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
             {
                 Input = { Positions = positions, ConstraintEdges = constraints, HoleSeeds = holes }
@@ -1817,6 +1897,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void HalfedgesForTriangulationWithRefinementTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types.");
+
             using var positions = new NativeArray<T>(new float2[]
             {
                 math.float2(0, 0),
@@ -1850,9 +1932,12 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void AutoHolesTest()
         {
-            using var positions = new NativeArray<T>(LakeSuperior.Points.DynamicCast<T>(), Allocator.Persistent);
+            var scaleFactor = typeof(T) == typeof(int2) ? 1000.0f : 1f;
+            var scaledPoints = LakeSuperior.Points.Select(p => p * scaleFactor).ToArray();
+            var scaledHoles = LakeSuperior.Holes.Select(h => h * scaleFactor).ToArray();
+            using var positions = new NativeArray<T>(scaledPoints.DynamicCast<T>(), Allocator.Persistent);
             using var constraintEdges = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
-            using var holes = new NativeArray<T>(LakeSuperior.Holes.DynamicCast<T>(), Allocator.Persistent);
+            using var holes = new NativeArray<T>(scaledHoles.DynamicCast<T>(), Allocator.Persistent);
 
             using var triangulator = new Triangulator<T>(1024 * 1024, Allocator.Persistent)
             {

--- a/Tests/UnsafeTriangulatorEditorTests.cs
+++ b/Tests/UnsafeTriangulatorEditorTests.cs
@@ -1,10 +1,12 @@
 using andywiecko.BurstTriangulator.LowLevel.Unsafe;
 using NUnit.Framework;
 using System;
+using System.Linq;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
+using UnityEngine.Animations;
 
 namespace andywiecko.BurstTriangulator.Editor.Tests
 {
@@ -82,7 +84,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             // All containers allocated with Allocator.Temp on the same thread use a shared
             // AtomicSafetyHandle instance rather than each having their own. Most of the time,
             // this isn't an issue because you can't pass Temp allocated collections into a job.
-            // 
+            //
             // However, when you use Native*HashMap, NativeParallelMultiHashMap, Native*HashSet,
             // and NativeList together with their secondary safety handle, this shared AtomicSafetyHandle
             // instance is a problem.
@@ -99,14 +101,23 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
 
     [TestFixture(typeof(float2))]
     [TestFixture(typeof(double2))]
+    [TestFixture(typeof(int2))]
     public class UnsafeTriangulatorEditorTests<T> where T : unmanaged
     {
+        static float ScaleFactor() => typeof(T) == typeof(int2) ? 1000 : 1;
+
+        static NativeArray<T> LakeSuperiorPoints(Allocator allocator) => new NativeArray<T>(LakeSuperior.Points.Select(i => i * ScaleFactor()).DynamicCast<T>().ToArray(), allocator);
+        static NativeArray<int> LakeSuperiorConstraints(Allocator allocator) => new NativeArray<int>(LakeSuperior.Constraints, allocator);
+        static NativeArray<T> LakeSuperiorHoles(Allocator allocator) => new NativeArray<T>(LakeSuperior.Holes.Select(i => i * ScaleFactor()).DynamicCast<T>().ToArray(), allocator);
+
         [Test]
         public void UnsafeTriangulatorOutputTrianglesTest([Values] bool constrain, [Values] bool refine, [Values] bool holes)
         {
-            using var positions = new NativeArray<T>(LakeSuperior.Points.DynamicCast<T>(), Allocator.Persistent);
-            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
-            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.DynamicCast<T>(), Allocator.Persistent);
+            if (refine && typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types");
+
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
+            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
             {
@@ -128,9 +139,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorOutputPositionsTest()
         {
-            using var positions = new NativeArray<T>(LakeSuperior.Points.DynamicCast<T>(), Allocator.Persistent);
-            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
-            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.DynamicCast<T>(), Allocator.Persistent);
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
+            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var outputPositions = new NativeList<T>(64, Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
@@ -153,9 +164,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorOutputHalfedgesTest()
         {
-            using var positions = new NativeArray<T>(LakeSuperior.Points.DynamicCast<T>(), Allocator.Persistent);
-            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
-            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.DynamicCast<T>(), Allocator.Persistent);
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
+            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var halfedges = new NativeList<int>(64, Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
@@ -178,9 +189,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorOutputConstrainedHalfedgesTest()
         {
-            using var positions = new NativeArray<T>(LakeSuperior.Points.DynamicCast<T>(), Allocator.Persistent);
-            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
-            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.DynamicCast<T>(), Allocator.Persistent);
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
+            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var constrainedHalfedges = new NativeList<bool>(64, Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
@@ -203,9 +214,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorOutputStatusTest()
         {
-            using var positions = new NativeArray<T>(LakeSuperior.Points.DynamicCast<T>(), Allocator.Persistent);
-            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
-            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.DynamicCast<T>(), Allocator.Persistent);
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
+            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var status = new NativeReference<Status>(Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
@@ -228,11 +239,13 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorPlantHoleSeedsAutoTest()
         {
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var input = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(),
-                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
+                Positions = positions,
+                ConstraintEdges = constraints,
             };
             var args = Args.Default(validateInput: false);
 
@@ -252,11 +265,14 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorPlantHoleSeedsRestoreBoundaryTest()
         {
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
+            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var input = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(),
-                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
+                Positions = positions,
+                ConstraintEdges = constraints,
             };
             var args = Args.Default(validateInput: false);
 
@@ -276,12 +292,15 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorPlantHoleSeedsHolesTest()
         {
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
+            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var inputWithHoles = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(),
-                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
-                HoleSeeds = LakeSuperior.Holes.DynamicCast<T>().AsNativeArray(),
+                Positions = positions,
+                ConstraintEdges = constraints,
+                HoleSeeds = holesSeeds,
             };
             var inputWithoutHoles = inputWithHoles;
             inputWithoutHoles.HoleSeeds = default;
@@ -304,10 +323,13 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorRefineMeshTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types");
+
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var input = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(),
+                Positions = positions,
             };
 
             using var triangles1 = new NativeList<int>(Allocator.Persistent);
@@ -334,11 +356,15 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorRefineMeshConstrainedTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types");
+
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var input = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(),
-                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
+                Positions = positions,
+                ConstraintEdges = constraints,
             };
             var args = Args.Default(validateInput: false, refineMesh: true, restoreBoundary: true);
 
@@ -366,12 +392,17 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorPlantHoleSeedsRefineMeshTest()
         {
+            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types");
+
+            using var positions = LakeSuperiorPoints(Allocator.Persistent);
+            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
+            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var inputWithHoles = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(),
-                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
-                HoleSeeds = LakeSuperior.Holes.DynamicCast<T>().AsNativeArray(),
+                Positions = positions,
+                ConstraintEdges = constraints,
+                HoleSeeds = holesSeeds,
             };
             var inputWithoutHoles = inputWithHoles;
             inputWithoutHoles.HoleSeeds = default;

--- a/Tests/UnsafeTriangulatorEditorTests.cs
+++ b/Tests/UnsafeTriangulatorEditorTests.cs
@@ -1,12 +1,9 @@
 using andywiecko.BurstTriangulator.LowLevel.Unsafe;
 using NUnit.Framework;
-using System;
-using System.Linq;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
-using UnityEngine.Animations;
 
 namespace andywiecko.BurstTriangulator.Editor.Tests
 {
@@ -84,7 +81,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             // All containers allocated with Allocator.Temp on the same thread use a shared
             // AtomicSafetyHandle instance rather than each having their own. Most of the time,
             // this isn't an issue because you can't pass Temp allocated collections into a job.
-            //
+            // 
             // However, when you use Native*HashMap, NativeParallelMultiHashMap, Native*HashSet,
             // and NativeList together with their secondary safety handle, this shared AtomicSafetyHandle
             // instance is a problem.
@@ -104,20 +101,17 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
     [TestFixture(typeof(int2))]
     public class UnsafeTriangulatorEditorTests<T> where T : unmanaged
     {
-        static float ScaleFactor() => typeof(T) == typeof(int2) ? 1000 : 1;
-
-        static NativeArray<T> LakeSuperiorPoints(Allocator allocator) => new NativeArray<T>(LakeSuperior.Points.Select(i => i * ScaleFactor()).DynamicCast<T>().ToArray(), allocator);
-        static NativeArray<int> LakeSuperiorConstraints(Allocator allocator) => new NativeArray<int>(LakeSuperior.Constraints, allocator);
-        static NativeArray<T> LakeSuperiorHoles(Allocator allocator) => new NativeArray<T>(LakeSuperior.Holes.Select(i => i * ScaleFactor()).DynamicCast<T>().ToArray(), allocator);
-
         [Test]
         public void UnsafeTriangulatorOutputTrianglesTest([Values] bool constrain, [Values] bool refine, [Values] bool holes)
         {
-            if (refine && typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types");
+            if (refine && typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
-            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
+            using var positions = new NativeArray<T>(LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
+            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
+            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
             {
@@ -139,9 +133,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorOutputPositionsTest()
         {
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
-            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
+            using var positions = new NativeArray<T>(LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
+            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
+            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var outputPositions = new NativeList<T>(64, Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
@@ -164,9 +158,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorOutputHalfedgesTest()
         {
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
-            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
+            using var positions = new NativeArray<T>(LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
+            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
+            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var halfedges = new NativeList<int>(64, Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
@@ -189,9 +183,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorOutputConstrainedHalfedgesTest()
         {
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
-            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
+            using var positions = new NativeArray<T>(LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
+            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
+            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var constrainedHalfedges = new NativeList<bool>(64, Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
@@ -214,9 +208,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorOutputStatusTest()
         {
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
-            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
+            using var positions = new NativeArray<T>(LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
+            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
+            using var holesSeeds = new NativeArray<T>(LakeSuperior.Holes.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>(), Allocator.Persistent);
             using var triangles = new NativeList<int>(64, Allocator.Persistent);
             using var status = new NativeReference<Status>(Allocator.Persistent);
             using var triangulator = new Triangulator<T>(Allocator.Persistent)
@@ -239,13 +233,11 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorPlantHoleSeedsAutoTest()
         {
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var input = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = positions,
-                ConstraintEdges = constraints,
+                Positions = LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>().AsNativeArray(),
+                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
             };
             var args = Args.Default(validateInput: false);
 
@@ -265,14 +257,11 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorPlantHoleSeedsRestoreBoundaryTest()
         {
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
-            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var input = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = positions,
-                ConstraintEdges = constraints,
+                Positions = LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>().AsNativeArray(),
+                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
             };
             var args = Args.Default(validateInput: false);
 
@@ -292,15 +281,12 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorPlantHoleSeedsHolesTest()
         {
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
-            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var inputWithHoles = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = positions,
-                ConstraintEdges = constraints,
-                HoleSeeds = holesSeeds,
+                Positions = LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>().AsNativeArray(),
+                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
+                HoleSeeds = LakeSuperior.Holes.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>().AsNativeArray(),
             };
             var inputWithoutHoles = inputWithHoles;
             inputWithoutHoles.HoleSeeds = default;
@@ -323,13 +309,15 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorRefineMeshTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var input = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = positions,
+                Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(),
             };
 
             using var triangles1 = new NativeList<int>(Allocator.Persistent);
@@ -356,15 +344,16 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorRefineMeshConstrainedTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var input = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = positions,
-                ConstraintEdges = constraints,
+                Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(),
+                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
             };
             var args = Args.Default(validateInput: false, refineMesh: true, restoreBoundary: true);
 
@@ -392,17 +381,17 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         [Test]
         public void UnsafeTriangulatorPlantHoleSeedsRefineMeshTest()
         {
-            if (typeof(T) == typeof(int2)) Assert.Ignore("Mesh refinement is not supported for integer types");
+            if (typeof(T) == typeof(int2))
+            {
+                Assert.Ignore("Mesh refinement is not supported for int2.");
+            }
 
-            using var positions = LakeSuperiorPoints(Allocator.Persistent);
-            using var constraints = LakeSuperiorConstraints(Allocator.Persistent);
-            using var holesSeeds = LakeSuperiorHoles(Allocator.Persistent);
             var t = new UnsafeTriangulator<T>();
             var inputWithHoles = new LowLevel.Unsafe.InputData<T>()
             {
-                Positions = positions,
-                ConstraintEdges = constraints,
-                HoleSeeds = holesSeeds,
+                Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(),
+                ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(),
+                HoleSeeds = LakeSuperior.Holes.DynamicCast<T>().AsNativeArray(),
             };
             var inputWithoutHoles = inputWithHoles;
             inputWithoutHoles.HoleSeeds = default;


### PR DESCRIPTION
Here I am again with integer support.
I figured it was best to open a new PR, since the old one is very different at this point.

Support:
All tests pass except:
* PCA transformations
* Mesh refinement

I have modified some tests to only have one unambiguous solution. Previously the integer and float code picked different, but equally valid, solutions to some tests.

There are two new generic types:
* TSquare: Used for squared distances and multiplication results. The integer implementation needs this to be able to use `long`s to avoid overflow.
* TFloat: Used for angles and other unitless fractional values.

The local transform is supported, but it only supports translations. No scaling or rotation. Those are inappropriate for integer coordinates anyway. Even offsets shouldn't really be used with integer coordinates. But it was easy to add support for it, so why not.

Since the integer code requires some primitives, like `circumCenter` to be handled differently, I have unfortunately had to introduce some code duplication between the float and double implementations. But it's a very small amount of code (and it's a lot easier to read when one can actually use infix operators). So I think that's fine. I suspect, but have not yet measured, that the new code can perform better since it better preserves the vectorized forms of the coordinates.

I have tried to keep all algorithms as similar as possible. A second PR can be done to clean up and simplify some parts.

I have not measured the performance yet.
![bild](https://github.com/user-attachments/assets/e91b466c-f7b6-4de3-a019-1096b48d0801)
![bild](https://github.com/user-attachments/assets/06b99e9b-0026-4f65-8591-f7a4f0860c72)
