### PR TITLE
feat: allocate profiler markers statically for improved performance

### DIFF
--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -422,6 +422,14 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
     {
         private static readonly TUtils utils = default;
 
+        static readonly ProfilerMarker MarkerPreProcessInputStep = new($"{nameof(PreProcessInputStep)}");
+        static readonly ProfilerMarker MarkerPostProcessInputStep = new($"{nameof(PostProcessInputStep)}");
+        static readonly ProfilerMarker MarkerValidateInputStep = new($"{nameof(ValidateInputStep)}");
+        static readonly ProfilerMarker MarkerDelaunayTriangulationStep = new($"{nameof(DelaunayTriangulationStep)}");
+        static readonly ProfilerMarker MarkerConstrainEdgesStep = new($"{nameof(ConstrainEdgesStep)}");
+        static readonly ProfilerMarker MarkerPlantingSeedStep = new($"{nameof(PlantingSeedStep)}");
+        static readonly ProfilerMarker MarkerRefineMeshStep = new($"{nameof(RefineMeshStep)}");
+
         public void Triangulate(InputData<T2> input, OutputData<T2> output, Args args, Allocator allocator)
         {
             var tmpStatus = default(NativeReference<Status>);
@@ -466,7 +474,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         private void PreProcessInputStep(InputData<T2> input, OutputData<T2> output, Args args, out NativeArray<T2> localHoles, out TTransform lt, Allocator allocator)
         {
-            using var _ = new ProfilerMarker($"{nameof(PreProcessInputStep)}").Auto();
+            using var _ = MarkerPreProcessInputStep.Auto();
 
             var localPositions = output.Positions;
             localPositions.ResizeUninitialized(input.Positions.Length);
@@ -498,7 +506,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         private void PostProcessInputStep(OutputData<T2> output, Args args, TTransform lt)
         {
-            using var _ = new ProfilerMarker($"{nameof(PostProcessInputStep)}").Auto();
+            using var _ = MarkerPostProcessInputStep.Auto();
             if (args.Preprocessor != Preprocessor.None)
             {
                 var inverse = lt.Inverse();
@@ -526,7 +534,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             public void Execute()
             {
-                using var _ = new ProfilerMarker($"{nameof(ValidateInputStep)}").Auto();
+                using var _ = MarkerValidateInputStep.Auto();
 
                 if (!args.ValidateInput)
                 {
@@ -737,7 +745,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             public void Execute(Allocator allocator)
             {
-                using var _ = new ProfilerMarker($"{nameof(DelaunayTriangulationStep)}").Auto();
+                using var _ = MarkerDelaunayTriangulationStep.Auto();
 
                 if (status.Value == Status.ERR)
                 {
@@ -1105,7 +1113,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             public void Execute(Allocator allocator)
             {
-                using var _ = new ProfilerMarker($"{nameof(ConstrainEdgesStep)}").Auto();
+                using var _ = MarkerConstrainEdgesStep.Auto();
 
                 if (!inputConstraintEdges.IsCreated || status.Value != Status.OK)
                 {
@@ -1480,7 +1488,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             public void Execute(Allocator allocator, bool constraintsIsCreated)
             {
-                using var _ = new ProfilerMarker($"{nameof(PlantingSeedStep)}").Auto();
+                using var _ = MarkerPlantingSeedStep.Auto();
 
                 if (!constraintsIsCreated || status.IsCreated && status.Value != Status.OK)
                 {
@@ -1783,7 +1791,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             public void Execute(Allocator allocator, bool refineMesh, bool constrainBoundary)
             {
-                using var _ = new ProfilerMarker($"{nameof(RefineMeshStep)}").Auto();
+                using var _ = MarkerRefineMeshStep.Auto();
 
                 if (!refineMesh || status.IsCreated && status.Value != Status.OK)
                 {


### PR DESCRIPTION
Previously, the markers were created every time the triangulation ran. This has a small overhead of having to transfer the string to the Unity profiler API. It's probably insignificant for larger triangulations, but could have an impact for very small ones.