### PR TITLE
feat: add vector2 support

### DIFF
--- a/Documentation~/manual/advanced/generic-coordinates.md
+++ b/Documentation~/manual/advanced/generic-coordinates.md
@@ -26,6 +26,7 @@ See benchmark for the generic coordinates [**here**][benchmark].
 | type                 | delaunay | constraints | holes      | refinement | preprocessors     | notes                       |
 | :------------------: | :------: | :---------: | :--------: | :--------: | :---------------: | :-------------------------: |
 | [`float2`][float2]   | ✔️       | ✔️         | ✔️         | ✔️         |✔️                |                             |
+| [`Vector2`][Vector2] | ✔️       | ✔️         | ✔️         | ✔️         |✔️                | Via [float2] reinterpret    |
 | [`double2`][double2] | ✔️       | ✔️         | ✔️         | ✔️         |✔️                |                             |
 | [`int2`][int2]       | ✔️       | ✔️         | 🟡[^holes] | ❌         |🟡[^preprocessors] | Support up to $\sim 2^{20}$ |
 
@@ -38,6 +39,7 @@ See benchmark for the generic coordinates [**here**][benchmark].
 [triangulatorT2]: xref:andywiecko.BurstTriangulator.Triangulator`1
 [extensions]: xref:andywiecko.BurstTriangulator.Extensions
 [float2]: xref:Unity.Mathematics.float2
+[Vector2]: xref:UnityEngine.Vector2
 [double2]: xref:Unity.Mathematics.double2
 [int2]: xref:Unity.Mathematics.int2
 [benchmark]: xref:benchmark-md#generic-coordinates

--- a/Documentation~/unity-xrefmap.yml
+++ b/Documentation~/unity-xrefmap.yml
@@ -24,6 +24,10 @@ references:
   name: float2
   href: https://docs.unity3d.com/Packages/com.unity.mathematics@1.3/api/Unity.Mathematics.float2.html
 
+- uid: UnityEngine.Vector2
+  name: Vector2
+  href: https://docs.unity3d.com/ScriptReference/Vector2.html
+
 - uid: Unity.Mathematics.double2
   name: double2
   href: https://docs.unity3d.com/Packages/com.unity.mathematics@1.3/api/Unity.Mathematics.double2.html

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -299,6 +299,19 @@ namespace andywiecko.BurstTriangulator
         public static JobHandle Schedule(this Triangulator<float2> @this, JobHandle dependencies = default) =>
             new TriangulationJob<float, float2, float, AffineTransform32, FloatUtils>(@this).Schedule(dependencies);
 
+        public static void Run(this Triangulator<Vector2> @this) =>
+            new TriangulationJob<float, float2, float, AffineTransform32, FloatUtils>(
+                input: new() { Positions = @this.Input.Positions.Reinterpret<float2>(), ConstraintEdges = @this.Input.ConstraintEdges, HoleSeeds = @this.Input.HoleSeeds.Reinterpret<float2>() },
+                output: new() { Triangles = @this.triangles, Halfedges = @this.halfedges, Positions = UnsafeUtility.As<NativeList<Vector2>, NativeList<float2>>(ref @this.outputPositions), Status = @this.status, ConstrainedHalfedges = @this.constrainedHalfedges },
+                args: @this.Settings
+        ).Run();
+        public static JobHandle Schedule(this Triangulator<Vector2> @this, JobHandle dependencies = default) =>
+            new TriangulationJob<float, float2, float, AffineTransform32, FloatUtils>(
+                input: new() { Positions = @this.Input.Positions.Reinterpret<float2>(), ConstraintEdges = @this.Input.ConstraintEdges, HoleSeeds = @this.Input.HoleSeeds.Reinterpret<float2>() },
+                output: new() { Triangles = @this.triangles, Halfedges = @this.halfedges, Positions = UnsafeUtility.As<NativeList<Vector2>, NativeList<float2>>(ref @this.outputPositions), Status = @this.status, ConstrainedHalfedges = @this.constrainedHalfedges },
+                args: @this.Settings
+        ).Schedule(dependencies);
+
         public static void Run(this Triangulator<double2> @this) =>
             new TriangulationJob<double, double2, double, AffineTransform64, DoubleUtils>(@this).Run();
         public static JobHandle Schedule(this Triangulator<double2> @this, JobHandle dependencies = default) =>
@@ -415,6 +428,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
     /// </remarks>
     /// <typeparam name="T2">The coordinate type. Supported types include:
     /// <see cref="float2"/>,
+    /// <see cref="Vector2"/>,
     /// <see cref="double2"/>,
     /// and
     /// <see cref="int2"/>.
@@ -427,18 +441,19 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
     {
         public static void Triangulate(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
         public static void PlantHoleSeeds(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
-        public static void RefineMesh(this UnsafeTriangulator @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+        public static void RefineMesh(this UnsafeTriangulator @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
 
         public static void Triangulate(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().Triangulate(input, output, args, allocator);
         public static void PlantHoleSeeds(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().PlantHoleSeeds(input, output, args, allocator);
-        public static void RefineMesh(this UnsafeTriangulator<float2> @this, OutputData<float2> output, Allocator allocator, float areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+        public static void RefineMesh(this UnsafeTriangulator<float2> @this, OutputData<float2> output, Allocator allocator, float areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+
+        public static void Triangulate(this UnsafeTriangulator<Vector2> @this, InputData<Vector2> input, OutputData<Vector2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().Triangulate(UnsafeUtility.As<InputData<Vector2>, InputData<float2>>(ref input), UnsafeUtility.As<OutputData<Vector2>, OutputData<float2>>(ref output), args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<Vector2> @this, InputData<Vector2> input, OutputData<Vector2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().PlantHoleSeeds(UnsafeUtility.As<InputData<Vector2>, InputData<float2>>(ref input), UnsafeUtility.As<OutputData<Vector2>, OutputData<float2>>(ref output), args, allocator);
+        public static void RefineMesh(this UnsafeTriangulator<Vector2> @this, OutputData<Vector2> output, Allocator allocator, float areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) => new UnsafeTriangulator<float, float2, float, AffineTransform32, FloatUtils>().RefineMesh(UnsafeUtility.As<OutputData<Vector2>, OutputData<float2>>(ref output), allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
 
         public static void Triangulate(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().Triangulate(input, output, args, allocator);
         public static void PlantHoleSeeds(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().PlantHoleSeeds(input, output, args, allocator);
-        public static void RefineMesh(this UnsafeTriangulator<double2> @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) =>
-            new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+        public static void RefineMesh(this UnsafeTriangulator<double2> @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) => new UnsafeTriangulator<double, double2, double, AffineTransform64, DoubleUtils>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
 
         public static void Triangulate(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TranslationInt, IntUtils>().Triangulate(input, output, args, allocator);
         public static void PlantHoleSeeds(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TranslationInt, IntUtils>().PlantHoleSeeds(input, output, args, allocator);
@@ -465,6 +480,21 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         private NativeReference<Status> status;
 
         private readonly Args args;
+
+        public TriangulationJob(InputData<T2> input, OutputData<T2> output, Args args)
+        {
+            inputPositions = input.Positions;
+            constraints = input.ConstraintEdges;
+            holeSeeds = input.HoleSeeds;
+
+            outputPositions = output.Positions;
+            triangles = output.Triangles;
+            halfedges = output.Halfedges;
+            constrainedHalfedges = output.ConstrainedHalfedges;
+            status = output.Status;
+
+            this.args = args;
+        }
 
         public TriangulationJob(Triangulator<T2> @this)
         {

--- a/Tests/TestUtils.cs
+++ b/Tests/TestUtils.cs
@@ -92,12 +92,17 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         public static T[] DynamicCast<T>(this IEnumerable<float2> data) where T : unmanaged =>
             data.Select(i => (T)(dynamic)i).ToArray();
         public static IEnumerable<float2> Scale(this IEnumerable<float2> data, float s, bool predicate) => data.Select(i => (predicate ? s : 1f) * i);
-        public static T[] DynamicCast<T>(this IEnumerable<double2> data) where T : unmanaged =>
-            data.Select(i => (T)(dynamic)i).ToArray();
+        public static T[] DynamicCast<T>(this IEnumerable<double2> data) where T : unmanaged => default(T) switch
+        {
+            // TODO: this extension can be removed entirely.
+            Vector2 _ => data.Select(i => (T)(dynamic)(float2)i).ToArray(),
+            _ => data.Select(i => (T)(dynamic)i).ToArray()
+        };
         public static IEqualityComparer<T> Comparer<T>(float epsilon = 0.0001f) => default(T) switch
         {
             float2 _ => Float2Comparer.With(epsilon) as IEqualityComparer<T>,
             double2 _ => Double2Comparer.With(epsilon) as IEqualityComparer<T>,
+            Vector2 _ => new Vector2EqualityComparer(epsilon) as IEqualityComparer<T>,
             _ => throw new NotImplementedException()
         };
         public static void Draw(this Triangulator triangulator, Color? color = null, float duration = 5f) => TestUtils.Draw(triangulator.Output.Positions.AsArray().Select(i => (float2)i).ToArray(), triangulator.Output.Triangles.AsArray().AsReadOnlySpan(), color ?? Color.red, duration);

--- a/Tests/UnsafeTriangulatorEditorTests.cs
+++ b/Tests/UnsafeTriangulatorEditorTests.cs
@@ -4,6 +4,7 @@ using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
+using UnityEngine;
 
 namespace andywiecko.BurstTriangulator.Editor.Tests
 {
@@ -104,6 +105,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
     }
 
     [TestFixture(typeof(float2))]
+    [TestFixture(typeof(Vector2))]
     [TestFixture(typeof(double2))]
     [TestFixture(typeof(int2))]
     public class UnsafeTriangulatorEditorTests<T> where T : unmanaged


### PR DESCRIPTION
Add `Vector2` support as a triangulation coordinate type. It is implemented via `float2` reinterpretation.