### PR TITLE
fix: missing dispose for temp data

### DIFF
--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -2157,8 +2157,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
                 using var _ = Markers.PlantingSeedStep.Auto();
 
-                visitedTriangles = new(triangles.Length / 3, allocator);
-                trianglesQueue = new(allocator);
+                using var _visitedTriangles = visitedTriangles = new(triangles.Length / 3, allocator);
+                using var _trianglesQueue = trianglesQueue = new(allocator);
 
                 if (args.AutoHolesAndBoundary) PlantAuto(allocator);
                 if (holes.IsCreated) PlantHoleSeeds(holes);

--- a/Tests/TriangulatorGenericsEditorTests.cs
+++ b/Tests/TriangulatorGenericsEditorTests.cs
@@ -22,8 +22,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         public void MeshRefinementIntSupportTest()
         {
             using var positions = new NativeArray<int2>(LakeSuperior.Points.Select(i => (int2)(i * 1000)).ToArray(), Allocator.Persistent);
-            var holes = new NativeArray<int2>(LakeSuperior.Holes.Select(i => (int2)(i * 1000)).ToArray(), Allocator.Persistent);
-            var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
+            using var holes = new NativeArray<int2>(LakeSuperior.Holes.Select(i => (int2)(i * 1000)).ToArray(), Allocator.Persistent);
+            using var constraints = new NativeArray<int>(LakeSuperior.Constraints, Allocator.Persistent);
 
             using var triangulator = new Triangulator<int2>(Allocator.Persistent)
             {


### PR DESCRIPTION
`Unity.Collections@2+` introduced a change in how it handles errors like `A Native Collection has not been disposed, resulting in a memory leak.` These memory leaks are now less noisy and require extra attention to manage. I'll need to consider how to incorporate these checks into the test suite.