### PR TITLE
docs: add demo info

### DIFF
--- a/Documentation~/demo/index.md
+++ b/Documentation~/demo/index.md
@@ -4,4 +4,17 @@ _disableToc: true
 
 # Demo online
 
+**Key bindings:**
+
+- <kbd>Mouse Wheel</kbd> – Zoom in/out.
+- <kbd>Right Mouse Button (RMB)</kbd> – Move the camera.
+- <kbd>Shift</kbd> + <kbd>RMB</kbd> – Move the camera *faster*.
+- <kbd>H</kbd> – Reset the camera to its default position (*home*).
+
+You can contribute to this demo scene in the following repository: [![Demo Repository](https://img.shields.io/github/stars/andywiecko/BurstTriangulator-Demo?label=BurstTriangulator-Demo)](https://github.com/andywiecko/BurstTriangulator-Demo)
+
+> [!IMPORTANT]  
+> The Burst compiler is currently not supported in WebGL builds.
+> Performance may be lower compared to other build targets.
+
 <iframe width="960" height="642" src="Demo/index.html" frameborder="0" scrolling="no" allowfullscreen></iframe>


### PR DESCRIPTION
Note: there is a new subpage in docs where one can check the basic capabilities of the package, see https://andywiecko.github.io/BurstTriangulator/demo