### PR TITLE
fix: refinement produces invalid result

### DIFF
--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -3118,7 +3118,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
                 if (heQueue.IsCreated)
                 {
-                    for (int i = 0; i < pathPoints.Length - 1; i++)
+                    for (int i = 0; i < pathPoints.Length; i++)
                     {
                         var he = heOffset + 3 * i + 1;
                         if (constrainedHalfedges[he] && IsEncroached(he))


### PR DESCRIPTION
Fixed an issue where refinement could produce invalid results in rare cases, particularly when the input contains subsegment clusters. These invalid cases manifested with addition of points outside the triangulation domain.

<br>

## Before

![image](https://github.com/user-attachments/assets/03919e16-3ae1-4632-8ee1-19746209936b)

## After

![image](https://github.com/user-attachments/assets/4911b0bf-e525-44f5-8411-3d5990ce1039)
