### PR TITLE
docs: update docfx json

### DIFF
--- a/Documentation~/docfx.json
+++ b/Documentation~/docfx.json
@@ -7,7 +7,10 @@
       "memberLayout": "separatePages",
       "enumSortOrder": "declaringOrder",
       "references": "dlls/*",
-      "properties": { "DefineConstants": "UNITY_MATHEMATICS_FIXEDPOINT" }
+      "properties": {
+         "DefineConstants": "UNITY_MATHEMATICS_FIXEDPOINT",
+         "AllowUnsafeBlocks": "true"
+      }
     }
   ],
   "build": {


### PR DESCRIPTION
Support for the `AllowUnsafeBlocks` field was introduced in DocFX version 2.78. This field is required to suppress warnings during documentation compilation.