### PR TITLE
feat: native input output data

### DIFF
--- a/Documentation~/manual/advanced/dynamic-triangulation.md
+++ b/Documentation~/manual/advanced/dynamic-triangulation.md
@@ -34,13 +34,23 @@ var t = new UnsafeTriangulator<float2>();
 
 using var positions = new NativeArray<float2>(..., Allocator.Persistent);
 using var constraints = new NativeArray<int>(..., Allocator.Persistent);
-var input = new InputData<float2> { Positions = positions, ConstraintEdges = constraints };
+var input = new NativeInputData<float2>
+{
+    Positions = positions,
+    ConstraintEdges = constraints
+};
 
 using var outputPositions = new NativeList<float2>(Allocator.Persistent);
 using var triangles = new NativeList<int>(Allocator.Persistent);
 using var halfedges = new NativeList<int>(Allocator.Persistent);
 using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
-var output = new OutputData<float2> { Positions = outputPositions, Triangles = triangles, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges };
+var output = new NativeOutputData<float2>
+{
+    Positions = outputPositions,
+    Triangles = triangles,
+    Halfedges = halfedges,
+    ConstrainedHalfedges = constrainedHalfedges
+};
 
 t.Triangulate(input, output, args: Args.Default(autoHolesAndBoundary: true), Allocator.Persistent);
 
@@ -81,13 +91,23 @@ var t = new UnsafeTriangulator<float2>();
 
 using var positions = new NativeArray<float2>(..., Allocator.Persistent);
 using var constraints = new NativeArray<int>(..., Allocator.Persistent);
-var input = new InputData<float2> { Positions = positions, ConstraintEdges = constraints };
+var input = new NativeInputData<float2>
+{
+    Positions = positions,
+    ConstraintEdges = constraints
+};
 
 using var outputPositions = new NativeList<float2>(Allocator.Persistent);
 using var triangles = new NativeList<int>(Allocator.Persistent);
 using var halfedges = new NativeList<int>(Allocator.Persistent);
 using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
-var output = new OutputData<float2> { Positions = outputPositions, Triangles = triangles, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges };
+var output = new NativeOutputData<float2>
+{
+    Positions = outputPositions,
+    Triangles = triangles,
+    Halfedges = halfedges,
+    ConstrainedHalfedges = constrainedHalfedges
+};
 
 t.Triangulate(input, output, args: Args.Default(autoHolesAndBoundary: true), Allocator.Persistent);
 
@@ -114,8 +134,8 @@ using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
 using var halfedges = new NativeList<int>(Allocator.Persistent);
 
 var t = new UnsafeTriangulator<double2>();
-var input = new InputData<double2> { Positions = inputPositions };
-var output = new OutputData<double2>
+var input = new NativeInputData<double2> { Positions = inputPositions };
+var output = new NativeOutputData<double2>
 {
     Positions = outputPositions,
     Triangles = triangles,

--- a/Documentation~/manual/advanced/unsafe-triangulator.md
+++ b/Documentation~/manual/advanced/unsafe-triangulator.md
@@ -49,8 +49,8 @@ Learn more in the [Parameters](#parameters) section about how to set up the tria
 All extension methods related to [`UnsafeTriangulator<T2>`][unsafe-triangulator] API except standard additional parameters,
 include custom struct parameters:
 
-- [`LowLevel.Unsafe.InputData<T2>`][n-input-data],
-- [`LowLevel.Unsafe.OutputData<T2>`][n-output-data],
+- [`LowLevel.Unsafe.NativeInputData<T2>`][n-input-data],
+- [`LowLevel.Unsafe.NativeOutputData<T2>`][n-output-data],
 - [`LowLevel.Unsafe.Args`][n-args].
 
 The first two structs are the same as managed types [`InputData<T2>`][m-input-data] and [`OutputData<T2>`][m-output-data], respectively. They have the same fields/properties.
@@ -80,7 +80,7 @@ Args args = settings;
 
 Below, you can find extensions (with descriptions and examples) that can be used with [`UnsafeTriangulator`][unsafe-triangulator]. Check out the unit tests for additional use cases.
 
-### `Triangulate`
+### Triangulate
 
 The extension [`Triangulate(input, output, args, allocator)`][triangulate] is the simplest option to use. The action of this extension essentially produces the same result as the [`Run`][run] method for the managed [`Triangulator`][triangulator]. It can be useful when triangulation is done with [`Allocator.Temp`][allocator-temp] in a single job or to combine this with different extensions.
 
@@ -97,12 +97,12 @@ new UnsafeTriangulator<float2>().Triangulate(
 );
 ```
 
-### `PlantHoleSeeds`
+### PlantHoleSeeds
 
 The extension [`PlantHoleSeeds(input, output, args, allocator)`][plant-seeds] is particularly useful when the user requires mesh data *without* removed triangles and additional mesh copy *with* removed triangles. In this case, the triangulation is performed once, which is generally a more expensive operation. Below is an example usage with the `autoHolesAndBoundary` option selected:
 
 ```csharp
-var input = new LowLevel.Unsafe.InputData<double2>
+var input = new NativeInputData<double2>
 {
     Positions = ...,
     ConstraintEdges = ...,
@@ -110,7 +110,7 @@ var input = new LowLevel.Unsafe.InputData<double2>
 using var triangles = new NativeList<int>(Allocator.Persistent);
 using var halfedges = new NativeList<int>(Allocator.Persistent);
 using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
-var output = new LowLevel.Unsafe.OutputData<double2>
+var output = new NativeOutputData<double2>
 {
     Triangles = triangles,
     Halfedges = halfedges,
@@ -123,9 +123,9 @@ t.PlantHoleSeeds(input, output, args.With(autoHolesAndBoundary: true), Allocator
 ```
 
 > [!NOTE]  
-> Depending on the options, some of the buffers may not be required for [`PlantHoleSeeds`][plant-seeds]. For example, when the user provides `HoleSeeds` in [`InputData<T2>`][n-output-data], `Positions` in [`OutputData<T2>`][n-output-data] must be provided. However, in other cases, it may not be required.
+> Depending on the options, some of the buffers may not be required for [`PlantHoleSeeds`][plant-seeds]. For example, when the user provides `HoleSeeds` in [`NativeInputData<T2>`][n-output-data], `Positions` in [`NativeOutputData<T2>`][n-output-data] must be provided. However, in other cases, it may not be required.
 
-### `RefineMesh`
+### RefineMesh
 
 The extension [`RefineMesh(output, allocator, areaThreshold?, angleThreshold?, concentricShells?, constrainBoundary?)`][refine-mesh] can be used to refine any triangulation mesh, even an already refined one. Please note that both the managed [`TriangulationSettings`][m-settings] and native [`Args`][n-args] provide refinement parameter setups only for [`float`][float] precision. This extension allows you to provide these parameters with the selected precision type `T` in generics. These parameters have the following default values (in the given precision type `T`, if this extension is available for `T`):
 
@@ -142,12 +142,12 @@ using var triangles = new NativeList<int>(Allocator.Persistent);
 using var halfedges = new NativeList<int>(Allocator.Persistent);
 using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
 using var outputPositions = new NativeList<float2>(Allocator.Persistent);
-var input = new LowLevel.Unsafe.InputData<float2>
+var input = new NativeInputData<float2>
 {
     Positions = ...,
     ConstraintEdges = ...,
 };
-var output = new LowLevel.Unsafe.OutputData<float2>
+var output = new NativeOutputData<float2>
 {
     Triangles = triangles,
     Halfedges = halfedges,
@@ -165,8 +165,8 @@ The [`UnsafeTriangulator<T>`][unsafe-triangulator] API also offers an option for
 
 [triangulator]: xref:andywiecko.BurstTriangulator.Triangulator`1
 [unsafe-triangulator]: xref:andywiecko.BurstTriangulator.LowLevel.Unsafe.UnsafeTriangulator`1
-[n-input-data]: xref:andywiecko.BurstTriangulator.LowLevel.Unsafe.InputData`1
-[n-output-data]: xref:andywiecko.BurstTriangulator.LowLevel.Unsafe.OutputData`1
+[n-input-data]: xref:andywiecko.BurstTriangulator.LowLevel.Unsafe.NativeInputData`1
+[n-output-data]: xref:andywiecko.BurstTriangulator.LowLevel.Unsafe.NativeOutputData`1
 [n-args]: xref:andywiecko.BurstTriangulator.LowLevel.Unsafe.Args
 [m-input-data]: xref:andywiecko.BurstTriangulator.InputData`1
 [m-output-data]: xref:andywiecko.BurstTriangulator.OutputData`1

--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -611,10 +611,52 @@ namespace andywiecko.BurstTriangulator
 namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 {
     /// <summary>
+    /// <b>Obsolete:</b> use <see cref="NativeInputData{T2}"/> instead.
+    /// </summary>
+    [Obsolete("Use " + nameof(NativeInputData<T2>) + "<> instead.")]
+    public struct InputData<T2> where T2 : unmanaged
+    {
+        public NativeArray<T2> Positions;
+        public NativeArray<int> ConstraintEdges;
+        public NativeArray<T2> HoleSeeds;
+        public NativeArray<bool> IgnoreConstraintForPlantingSeeds;
+        public static implicit operator NativeInputData<T2>(InputData<T2> @this) => new()
+        {
+            Positions = @this.Positions,
+            ConstraintEdges = @this.ConstraintEdges,
+            HoleSeeds = @this.HoleSeeds,
+            IgnoreConstraintForPlantingSeeds = @this.IgnoreConstraintForPlantingSeeds,
+        };
+    }
+
+    /// <summary>
+    /// <b>Obsolete:</b> use <see cref="NativeOutputData{T2}"/> instead.
+    /// </summary>
+    [Obsolete("Use " + nameof(NativeOutputData<T2>) + "<> instead.")]
+    public struct OutputData<T2> where T2 : unmanaged
+    {
+        public NativeList<T2> Positions;
+        public NativeList<int> Triangles;
+        public NativeReference<Status> Status;
+        public NativeList<int> Halfedges;
+        public NativeList<bool> ConstrainedHalfedges;
+        public NativeList<bool> IgnoredHalfedgesForPlantingSeeds;
+        public static implicit operator NativeOutputData<T2>(OutputData<T2> @this) => new()
+        {
+            Positions = @this.Positions,
+            Triangles = @this.Triangles,
+            Status = @this.Status,
+            Halfedges = @this.Halfedges,
+            ConstrainedHalfedges = @this.ConstrainedHalfedges,
+            IgnoredHalfedgesForPlantingSeeds = @this.IgnoredHalfedgesForPlantingSeeds,
+        };
+    }
+
+    /// <summary>
     /// Native correspondence to <see cref="BurstTriangulator.InputData{T2}"/>.
     /// </summary>
     /// <seealso cref="BurstTriangulator.InputData{T2}"/>
-    public struct InputData<T2> where T2 : unmanaged
+    public struct NativeInputData<T2> where T2 : unmanaged
     {
         /// <summary>
         /// Positions of points used in triangulation.
@@ -646,13 +688,13 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
     /// Native correspondence to <see cref="BurstTriangulator.OutputData{T2}"/>.
     /// </summary>
     /// <seealso cref="BurstTriangulator.OutputData{T2}"/>
-    public struct OutputData<T2> where T2 : unmanaged
+    public struct NativeOutputData<T2> where T2 : unmanaged
     {
         /// <summary>
         /// Positions of triangulation points.
         /// </summary>
         /// <remarks>
-        /// <b>Note:</b> This buffer may include additional points than <see cref="InputData{T2}.Positions"/> if refinement is enabled. 
+        /// <b>Note:</b> This buffer may include additional points than <see cref="NativeInputData{T2}.Positions"/> if refinement is enabled. 
         /// Additionally, the positions might differ slightly (by a small ε) if a <see cref="Args.Preprocessor"/> is applied.
         /// </remarks>
         public NativeList<T2> Positions;
@@ -675,7 +717,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// <seealso cref="IgnoredHalfedgesForPlantingSeeds"/>
         public NativeList<bool> ConstrainedHalfedges;
         /// <summary>
-        /// Buffer corresponding to <see cref="Halfedges"/>. <see langword="true"/> indicates that the halfedge was ignored during planting seed step, <see langword="false"/> otherwise. Constraint edges to ignore can be set in input using <see cref="InputData{T2}.IgnoreConstraintForPlantingSeeds"/>.
+        /// Buffer corresponding to <see cref="Halfedges"/>. <see langword="true"/> indicates that the halfedge was ignored during planting seed step, <see langword="false"/> otherwise. Constraint edges to ignore can be set in input using <see cref="NativeInputData{T2}.IgnoreConstraintForPlantingSeeds"/>.
         /// </summary>
         /// <seealso cref="ConstrainedHalfedges"/>
         public NativeList<bool> IgnoredHalfedgesForPlantingSeeds;
@@ -806,7 +848,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void Triangulate(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double2>().Triangulate(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator @this, NativeInputData<double2> input, NativeOutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double2>().Triangulate(input, output, args, allocator);
         /// <summary>
         /// Plants hole seeds defined in <paramref name="input"/> (or restores boundaries or auto-holes if specified in <paramref name="args"/>)
         /// within the triangulation data in <paramref name="output"/>, using the settings specified in <paramref name="args"/>.
@@ -817,7 +859,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void PlantHoleSeeds(this UnsafeTriangulator @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double2>().PlantHoleSeeds(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator @this, NativeInputData<double2> input, NativeOutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double2>().PlantHoleSeeds(input, output, args, allocator);
         /// <summary>
         /// Refines the mesh for a valid triangulation in <paramref name="output"/>.
         /// Refinement parameters can be provided with the selected precision type T in generics, which is especially useful for fixed-point arithmetic.
@@ -831,7 +873,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
         /// <param name="angleThreshold">Expressed in <em>radians</em>. Default: 5° = 0.0872664626 rad.</param>
         /// <param name="constrainBoundary">Used to constrain boundary halfedges. Since the refinement algorithm (whether for constrained triangulation or not) requires constrained halfedges at the boundary, not setting this option may cause unexpected behavior, especially when the restoreBoundary option is disabled.</param>
-        public static void RefineMesh(this UnsafeTriangulator @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) => new UnsafeTriangulator<double2>().RefineMesh(output, allocator, areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+        public static void RefineMesh(this UnsafeTriangulator @this, NativeOutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) => new UnsafeTriangulator<double2>().RefineMesh(output, allocator, areaThreshold, angleThreshold, concentricShells, constrainBoundary);
         /// <summary>
         /// Inserts a point into the given triangulation <paramref name="output"/> within the triangle at index <paramref name="tId"/>, using the specified barycentric coordinates <paramref name="bar"/>.
         /// For faster triangle lookup when inserting a point at specific coordinates, it is recommended to use an acceleration structure (e.g., bounding volume tree, buckets, etc.).
@@ -848,7 +890,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// All coordinates should be in the range (0, 1), and <paramref name="bar"/>.x + <paramref name="bar"/>.y + <paramref name="bar"/>.z must equal 1.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicInsertPoint(this UnsafeTriangulator @this, OutputData<double2> output, int tId, double3 bar, Allocator allocator) => new UnsafeTriangulator<double2>().DynamicInsertPoint(output, tId, bar, allocator);
+        public static void DynamicInsertPoint(this UnsafeTriangulator @this, NativeOutputData<double2> output, int tId, double3 bar, Allocator allocator) => new UnsafeTriangulator<double2>().DynamicInsertPoint(output, tId, bar, allocator);
         /// <summary>
         /// Splits the halfedge specified by <paramref name="he"/> by inserting a point at a position determined by linear interpolation.
         /// The position is interpolated between the start and end points of the halfedge in the triangulation <paramref name="output"/> 
@@ -867,7 +909,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// where <c>p = (1 - alpha) * start + alpha * end</c>.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicSplitHalfedge(this UnsafeTriangulator @this, OutputData<double2> output, int he, double alpha, Allocator allocator) => new UnsafeTriangulator<double2>().DynamicSplitHalfedge(output, he, alpha, allocator);
+        public static void DynamicSplitHalfedge(this UnsafeTriangulator @this, NativeOutputData<double2> output, int he, double alpha, Allocator allocator) => new UnsafeTriangulator<double2>().DynamicSplitHalfedge(output, he, alpha, allocator);
         /// <summary>
         /// Removes the specified point <paramref name="pId"/> from the <paramref name="output"/> data
         /// and re-triangulates the affected region to maintain a valid triangulation.
@@ -880,7 +922,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// </remarks>
         /// <param name="pId">The index of the <b>bulk</b> point to remove.</param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator @this, OutputData<double2> output, int pId, Allocator allocator) => new UnsafeTriangulator<double2>().DynamicRemoveBulkPoint(output, pId, allocator);
+        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator @this, NativeOutputData<double2> output, int pId, Allocator allocator) => new UnsafeTriangulator<double2>().DynamicRemoveBulkPoint(output, pId, allocator);
 
         /// <summary>
         /// Performs triangulation on the given <paramref name="input"/>, producing the result in <paramref name="output"/> based on the settings specified in <paramref name="args"/>.
@@ -891,7 +933,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void Triangulate(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().Triangulate(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<float2> @this, NativeInputData<float2> input, NativeOutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().Triangulate(input, output, args, allocator);
         /// <summary>
         /// Plants hole seeds defined in <paramref name="input"/> (or restores boundaries or auto-holes if specified in <paramref name="args"/>)
         /// within the triangulation data in <paramref name="output"/>, using the settings specified in <paramref name="args"/>.
@@ -902,7 +944,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void PlantHoleSeeds(this UnsafeTriangulator<float2> @this, InputData<float2> input, OutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().PlantHoleSeeds(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<float2> @this, NativeInputData<float2> input, NativeOutputData<float2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().PlantHoleSeeds(input, output, args, allocator);
         /// <summary>
         /// Refines the mesh for a valid triangulation in <paramref name="output"/>.
         /// Refinement parameters can be provided with the selected precision type T in generics, which is especially useful for fixed-point arithmetic.
@@ -916,7 +958,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
         /// <param name="angleThreshold">Expressed in <em>radians</em>. Default: 5° = 0.0872664626 rad.</param>
         /// <param name="constrainBoundary">Used to constrain boundary halfedges. Since the refinement algorithm (whether for constrained triangulation or not) requires constrained halfedges at the boundary, not setting this option may cause unexpected behavior, especially when the restoreBoundary option is disabled.</param>
-        public static void RefineMesh(this UnsafeTriangulator<float2> @this, OutputData<float2> output, Allocator allocator, float areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+        public static void RefineMesh(this UnsafeTriangulator<float2> @this, NativeOutputData<float2> output, Allocator allocator, float areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
         /// <summary>
         /// Inserts a point into the given triangulation <paramref name="output"/> within the triangle at index <paramref name="tId"/>, using the specified barycentric coordinates <paramref name="bar"/>.
         /// For faster triangle lookup when inserting a point at specific coordinates, it is recommended to use an acceleration structure (e.g., bounding volume tree, buckets, etc.).
@@ -933,7 +975,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// All coordinates should be in the range (0, 1), and <paramref name="bar"/>.x + <paramref name="bar"/>.y + <paramref name="bar"/>.z must equal 1.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicInsertPoint(this UnsafeTriangulator<float2> @this, OutputData<float2> output, int tId, float3 bar, Allocator allocator)
+        public static void DynamicInsertPoint(this UnsafeTriangulator<float2> @this, NativeOutputData<float2> output, int tId, float3 bar, Allocator allocator)
         {
             var (t0, t1, t2) = (output.Triangles[3 * tId + 0], output.Triangles[3 * tId + 1], output.Triangles[3 * tId + 2]);
             var (p0, p1, p2) = (output.Positions[t0], output.Positions[t1], output.Positions[t2]);
@@ -958,7 +1000,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// where <c>p = (1 - alpha) * start + alpha * end</c>.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicSplitHalfedge(this UnsafeTriangulator<float2> @this, OutputData<float2> output, int he, float alpha, Allocator allocator) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().DynamicSplitHalfedge(output, he, alpha, allocator);
+        public static void DynamicSplitHalfedge(this UnsafeTriangulator<float2> @this, NativeOutputData<float2> output, int he, float alpha, Allocator allocator) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().DynamicSplitHalfedge(output, he, alpha, allocator);
         /// <summary>
         /// Removes the specified point <paramref name="pId"/> from the <paramref name="output"/> data
         /// and re-triangulates the affected region to maintain a valid triangulation.
@@ -971,7 +1013,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// </remarks>
         /// <param name="pId">The index of the <b>bulk</b> point to remove.</param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator<float2> @this, OutputData<float2> output, int pId, Allocator allocator) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().DynamicRemoveBulkPoint(output, pId, allocator);
+        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator<float2> @this, NativeOutputData<float2> output, int pId, Allocator allocator) => new UnsafeTriangulator<float, float2, float, TransformFloat, UtilsFloat>().DynamicRemoveBulkPoint(output, pId, allocator);
 
         /// <summary>
         /// Performs triangulation on the given <paramref name="input"/>, producing the result in <paramref name="output"/> based on the settings specified in <paramref name="args"/>.
@@ -982,7 +1024,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void Triangulate(this UnsafeTriangulator<Vector2> @this, InputData<Vector2> input, OutputData<Vector2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float2>().Triangulate(UnsafeUtility.As<InputData<Vector2>, InputData<float2>>(ref input), UnsafeUtility.As<OutputData<Vector2>, OutputData<float2>>(ref output), args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<Vector2> @this, NativeInputData<Vector2> input, NativeOutputData<Vector2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float2>().Triangulate(UnsafeUtility.As<NativeInputData<Vector2>, NativeInputData<float2>>(ref input), UnsafeUtility.As<NativeOutputData<Vector2>, NativeOutputData<float2>>(ref output), args, allocator);
         /// <summary>
         /// Plants hole seeds defined in <paramref name="input"/> (or restores boundaries or auto-holes if specified in <paramref name="args"/>)
         /// within the triangulation data in <paramref name="output"/>, using the settings specified in <paramref name="args"/>.
@@ -993,7 +1035,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void PlantHoleSeeds(this UnsafeTriangulator<Vector2> @this, InputData<Vector2> input, OutputData<Vector2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float2>().PlantHoleSeeds(UnsafeUtility.As<InputData<Vector2>, InputData<float2>>(ref input), UnsafeUtility.As<OutputData<Vector2>, OutputData<float2>>(ref output), args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<Vector2> @this, NativeInputData<Vector2> input, NativeOutputData<Vector2> output, Args args, Allocator allocator) => new UnsafeTriangulator<float2>().PlantHoleSeeds(UnsafeUtility.As<NativeInputData<Vector2>, NativeInputData<float2>>(ref input), UnsafeUtility.As<NativeOutputData<Vector2>, NativeOutputData<float2>>(ref output), args, allocator);
         /// <summary>
         /// Refines the mesh for a valid triangulation in <paramref name="output"/>.
         /// Refinement parameters can be provided with the selected precision type T in generics, which is especially useful for fixed-point arithmetic.
@@ -1007,7 +1049,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
         /// <param name="angleThreshold">Expressed in <em>radians</em>. Default: 5° = 0.0872664626 rad.</param>
         /// <param name="constrainBoundary">Used to constrain boundary halfedges. Since the refinement algorithm (whether for constrained triangulation or not) requires constrained halfedges at the boundary, not setting this option may cause unexpected behavior, especially when the restoreBoundary option is disabled.</param>
-        public static void RefineMesh(this UnsafeTriangulator<Vector2> @this, OutputData<Vector2> output, Allocator allocator, float areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) => new UnsafeTriangulator<float2>().RefineMesh(UnsafeUtility.As<OutputData<Vector2>, OutputData<float2>>(ref output), allocator, areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+        public static void RefineMesh(this UnsafeTriangulator<Vector2> @this, NativeOutputData<Vector2> output, Allocator allocator, float areaThreshold = 1, float angleThreshold = 0.0872664626f, float concentricShells = 0.001f, bool constrainBoundary = false) => new UnsafeTriangulator<float2>().RefineMesh(UnsafeUtility.As<NativeOutputData<Vector2>, NativeOutputData<float2>>(ref output), allocator, areaThreshold, angleThreshold, concentricShells, constrainBoundary);
         /// <summary>
         /// Inserts a point into the given triangulation <paramref name="output"/> within the triangle at index <paramref name="tId"/>, using the specified barycentric coordinates <paramref name="bar"/>.
         /// For faster triangle lookup when inserting a point at specific coordinates, it is recommended to use an acceleration structure (e.g., bounding volume tree, buckets, etc.).
@@ -1024,8 +1066,8 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// All coordinates should be in the range (0, 1), and <paramref name="bar"/>.x + <paramref name="bar"/>.y + <paramref name="bar"/>.z must equal 1.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicInsertPoint(this UnsafeTriangulator<Vector2> @this, OutputData<Vector2> output, int tId, Vector3 bar, Allocator allocator) =>
-            new UnsafeTriangulator<float2>().DynamicInsertPoint(UnsafeUtility.As<OutputData<Vector2>, OutputData<float2>>(ref output), tId, bar, allocator);
+        public static void DynamicInsertPoint(this UnsafeTriangulator<Vector2> @this, NativeOutputData<Vector2> output, int tId, Vector3 bar, Allocator allocator) =>
+            new UnsafeTriangulator<float2>().DynamicInsertPoint(UnsafeUtility.As<NativeOutputData<Vector2>, NativeOutputData<float2>>(ref output), tId, bar, allocator);
         /// <summary>
         /// Splits the halfedge specified by <paramref name="he"/> by inserting a point at a position determined by linear interpolation.
         /// The position is interpolated between the start and end points of the halfedge in the triangulation <paramref name="output"/> 
@@ -1044,7 +1086,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// where <c>p = (1 - alpha) * start + alpha * end</c>.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicSplitHalfedge(this UnsafeTriangulator<Vector2> @this, OutputData<Vector2> output, int he, float alpha, Allocator allocator) => new UnsafeTriangulator<float2>().DynamicSplitHalfedge(UnsafeUtility.As<OutputData<Vector2>, OutputData<float2>>(ref output), he, alpha, allocator);
+        public static void DynamicSplitHalfedge(this UnsafeTriangulator<Vector2> @this, NativeOutputData<Vector2> output, int he, float alpha, Allocator allocator) => new UnsafeTriangulator<float2>().DynamicSplitHalfedge(UnsafeUtility.As<NativeOutputData<Vector2>, NativeOutputData<float2>>(ref output), he, alpha, allocator);
         /// <summary>
         /// Removes the specified point <paramref name="pId"/> from the <paramref name="output"/> data
         /// and re-triangulates the affected region to maintain a valid triangulation.
@@ -1057,7 +1099,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// </remarks>
         /// <param name="pId">The index of the <b>bulk</b> point to remove.</param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator<Vector2> @this, OutputData<Vector2> output, int pId, Allocator allocator) => new UnsafeTriangulator<float2>().DynamicRemoveBulkPoint(UnsafeUtility.As<OutputData<Vector2>, OutputData<float2>>(ref output), pId, allocator);
+        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator<Vector2> @this, NativeOutputData<Vector2> output, int pId, Allocator allocator) => new UnsafeTriangulator<float2>().DynamicRemoveBulkPoint(UnsafeUtility.As<NativeOutputData<Vector2>, NativeOutputData<float2>>(ref output), pId, allocator);
 
         /// <summary>
         /// Performs triangulation on the given <paramref name="input"/>, producing the result in <paramref name="output"/> based on the settings specified in <paramref name="args"/>.
@@ -1068,7 +1110,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void Triangulate(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().Triangulate(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<double2> @this, NativeInputData<double2> input, NativeOutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().Triangulate(input, output, args, allocator);
         /// <summary>
         /// Plants hole seeds defined in <paramref name="input"/> (or restores boundaries or auto-holes if specified in <paramref name="args"/>)
         /// within the triangulation data in <paramref name="output"/>, using the settings specified in <paramref name="args"/>.
@@ -1079,7 +1121,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void PlantHoleSeeds(this UnsafeTriangulator<double2> @this, InputData<double2> input, OutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().PlantHoleSeeds(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<double2> @this, NativeInputData<double2> input, NativeOutputData<double2> output, Args args, Allocator allocator) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().PlantHoleSeeds(input, output, args, allocator);
         /// <summary>
         /// Refines the mesh for a valid triangulation in <paramref name="output"/>.
         /// Refinement parameters can be provided with the selected precision type T in generics, which is especially useful for fixed-point arithmetic.
@@ -1093,7 +1135,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
         /// <param name="angleThreshold">Expressed in <em>radians</em>. Default: 5° = 0.0872664626 rad.</param>
         /// <param name="constrainBoundary">Used to constrain boundary halfedges. Since the refinement algorithm (whether for constrained triangulation or not) requires constrained halfedges at the boundary, not setting this option may cause unexpected behavior, especially when the restoreBoundary option is disabled.</param>
-        public static void RefineMesh(this UnsafeTriangulator<double2> @this, OutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
+        public static void RefineMesh(this UnsafeTriangulator<double2> @this, NativeOutputData<double2> output, Allocator allocator, double areaThreshold = 1, double angleThreshold = 0.0872664626, double concentricShells = 0.001, bool constrainBoundary = false) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().RefineMesh(output, allocator, 2 * areaThreshold, angleThreshold, concentricShells, constrainBoundary);
         /// <summary>
         /// Inserts a point into the given triangulation <paramref name="output"/> within the triangle at index <paramref name="tId"/>, using the specified barycentric coordinates <paramref name="bar"/>.
         /// For faster triangle lookup when inserting a point at specific coordinates, it is recommended to use an acceleration structure (e.g., bounding volume tree, buckets, etc.).
@@ -1110,7 +1152,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// All coordinates should be in the range (0, 1), and <paramref name="bar"/>.x + <paramref name="bar"/>.y + <paramref name="bar"/>.z must equal 1.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicInsertPoint(this UnsafeTriangulator<double2> @this, OutputData<double2> output, int tId, double3 bar, Allocator allocator)
+        public static void DynamicInsertPoint(this UnsafeTriangulator<double2> @this, NativeOutputData<double2> output, int tId, double3 bar, Allocator allocator)
         {
             var (t0, t1, t2) = (output.Triangles[3 * tId + 0], output.Triangles[3 * tId + 1], output.Triangles[3 * tId + 2]);
             var (p0, p1, p2) = (output.Positions[t0], output.Positions[t1], output.Positions[t2]);
@@ -1135,7 +1177,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// where <c>p = (1 - alpha) * start + alpha * end</c>.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicSplitHalfedge(this UnsafeTriangulator<double2> @this, OutputData<double2> output, int he, double alpha, Allocator allocator) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().DynamicSplitHalfedge(output, he, alpha, allocator);
+        public static void DynamicSplitHalfedge(this UnsafeTriangulator<double2> @this, NativeOutputData<double2> output, int he, double alpha, Allocator allocator) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().DynamicSplitHalfedge(output, he, alpha, allocator);
         /// <summary>
         /// Removes the specified point <paramref name="pId"/> from the <paramref name="output"/> data
         /// and re-triangulates the affected region to maintain a valid triangulation.
@@ -1148,7 +1190,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// </remarks>
         /// <param name="pId">The index of the <b>bulk</b> point to remove.</param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator<double2> @this, OutputData<double2> output, int pId, Allocator allocator) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().DynamicRemoveBulkPoint(output, pId, allocator);
+        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator<double2> @this, NativeOutputData<double2> output, int pId, Allocator allocator) => new UnsafeTriangulator<double, double2, double, TransformDouble, UtilsDouble>().DynamicRemoveBulkPoint(output, pId, allocator);
 
         /// <summary>
         /// Performs triangulation on the given <paramref name="input"/>, producing the result in <paramref name="output"/> based on the settings specified in <paramref name="args"/>.
@@ -1159,7 +1201,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void Triangulate(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TransformInt, UtilsInt>().Triangulate(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<int2> @this, NativeInputData<int2> input, NativeOutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TransformInt, UtilsInt>().Triangulate(input, output, args, allocator);
         /// <summary>
         /// Plants hole seeds defined in <paramref name="input"/> (or restores boundaries or auto-holes if specified in <paramref name="args"/>)
         /// within the triangulation data in <paramref name="output"/>, using the settings specified in <paramref name="args"/>.
@@ -1170,7 +1212,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void PlantHoleSeeds(this UnsafeTriangulator<int2> @this, InputData<int2> input, OutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TransformInt, UtilsInt>().PlantHoleSeeds(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<int2> @this, NativeInputData<int2> input, NativeOutputData<int2> output, Args args, Allocator allocator) => new UnsafeTriangulator<int, int2, long, TransformInt, UtilsInt>().PlantHoleSeeds(input, output, args, allocator);
 
 #if UNITY_MATHEMATICS_FIXEDPOINT
         /// <summary>
@@ -1182,7 +1224,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void Triangulate(this UnsafeTriangulator<fp2> @this, InputData<fp2> input, OutputData<fp2> output, Args args, Allocator allocator) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().Triangulate(input, output, args, allocator);
+        public static void Triangulate(this UnsafeTriangulator<fp2> @this, NativeInputData<fp2> input, NativeOutputData<fp2> output, Args args, Allocator allocator) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().Triangulate(input, output, args, allocator);
         /// <summary>
         /// Plants hole seeds defined in <paramref name="input"/> (or restores boundaries or auto-holes if specified in <paramref name="args"/>)
         /// within the triangulation data in <paramref name="output"/>, using the settings specified in <paramref name="args"/>.
@@ -1193,7 +1235,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// The <paramref name="input"/> and <paramref name="output"/> native containers must be allocated by the user. Some buffers are optional; refer to the documentation for more details.
         /// </remarks>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void PlantHoleSeeds(this UnsafeTriangulator<fp2> @this, InputData<fp2> input, OutputData<fp2> output, Args args, Allocator allocator) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().PlantHoleSeeds(input, output, args, allocator);
+        public static void PlantHoleSeeds(this UnsafeTriangulator<fp2> @this, NativeInputData<fp2> input, NativeOutputData<fp2> output, Args args, Allocator allocator) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().PlantHoleSeeds(input, output, args, allocator);
         /// <summary>
         /// Refines the mesh for a valid triangulation in <paramref name="output"/>.
         /// Refinement parameters can be provided with the selected precision type T in generics, which is especially useful for fixed-point arithmetic.
@@ -1207,7 +1249,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
         /// <param name="angleThreshold">Expressed in <em>radians</em>. Default: 5° = 0.0872664626 rad.</param>
         /// <param name="constrainBoundary">Used to constrain boundary halfedges. Since the refinement algorithm (whether for constrained triangulation or not) requires constrained halfedges at the boundary, not setting this option may cause unexpected behavior, especially when the restoreBoundary option is disabled.</param>
-        public static void RefineMesh(this UnsafeTriangulator<fp2> @this, OutputData<fp2> output, Allocator allocator, fp? areaThreshold = null, fp? angleThreshold = null, fp? concentricShells = null, bool constrainBoundary = false) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().RefineMesh(output, allocator, 2 * (areaThreshold ?? 1), angleThreshold ?? fp.FromRaw(374806602) /*Raw value for (fp)0.0872664626*/, concentricShells ?? fp.FromRaw(4294967) /*Raw value for (fp)1 / 1000*/, constrainBoundary);
+        public static void RefineMesh(this UnsafeTriangulator<fp2> @this, NativeOutputData<fp2> output, Allocator allocator, fp? areaThreshold = null, fp? angleThreshold = null, fp? concentricShells = null, bool constrainBoundary = false) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().RefineMesh(output, allocator, 2 * (areaThreshold ?? 1), angleThreshold ?? fp.FromRaw(374806602) /*Raw value for (fp)0.0872664626*/, concentricShells ?? fp.FromRaw(4294967) /*Raw value for (fp)1 / 1000*/, constrainBoundary);
         /// <summary>
         /// Inserts a point into the given triangulation <paramref name="output"/> within the triangle at index <paramref name="tId"/>, using the specified barycentric coordinates <paramref name="bar"/>.
         /// For faster triangle lookup when inserting a point at specific coordinates, it is recommended to use an acceleration structure (e.g., bounding volume tree, buckets, etc.).
@@ -1224,7 +1266,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// All coordinates should be in the range (0, 1), and <paramref name="bar"/>.x + <paramref name="bar"/>.y + <paramref name="bar"/>.z must equal 1.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicInsertPoint(this UnsafeTriangulator<fp2> @this, OutputData<fp2> output, int tId, fp3 bar, Allocator allocator)
+        public static void DynamicInsertPoint(this UnsafeTriangulator<fp2> @this, NativeOutputData<fp2> output, int tId, fp3 bar, Allocator allocator)
         {
             var (t0, t1, t2) = (output.Triangles[3 * tId + 0], output.Triangles[3 * tId + 1], output.Triangles[3 * tId + 2]);
             var (p0, p1, p2) = (output.Positions[t0], output.Positions[t1], output.Positions[t2]);
@@ -1249,7 +1291,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// where <c>p = (1 - alpha) * start + alpha * end</c>.
         /// </param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicSplitHalfedge(this UnsafeTriangulator<fp2> @this, OutputData<fp2> output, int he, fp alpha, Allocator allocator) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().DynamicSplitHalfedge(output, he, alpha, allocator);
+        public static void DynamicSplitHalfedge(this UnsafeTriangulator<fp2> @this, NativeOutputData<fp2> output, int he, fp alpha, Allocator allocator) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().DynamicSplitHalfedge(output, he, alpha, allocator);
         /// <summary>
         /// Removes the specified point <paramref name="pId"/> from the <paramref name="output"/> data
         /// and re-triangulates the affected region to maintain a valid triangulation.
@@ -1262,7 +1304,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
         /// </remarks>
         /// <param name="pId">The index of the <b>bulk</b> point to remove.</param>
         /// <param name="allocator">The allocator to use. If called from a job, consider using <see cref="Allocator.Temp"/>.</param>
-        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator<fp2> @this, OutputData<fp2> output, int pId, Allocator allocator) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().DynamicRemoveBulkPoint(output, pId, allocator);
+        public static void DynamicRemoveBulkPoint(this UnsafeTriangulator<fp2> @this, NativeOutputData<fp2> output, int pId, Allocator allocator) => new UnsafeTriangulator<fp, fp2, fp, TransformFp, UtilsFp>().DynamicRemoveBulkPoint(output, pId, allocator);
 #endif
     }
 
@@ -1341,7 +1383,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         private readonly Args args;
 
-        public TriangulationJob(InputData<T2> input, OutputData<T2> output, Args args)
+        public TriangulationJob(NativeInputData<T2> input, NativeOutputData<T2> output, Args args)
         {
             inputPositions = input.Positions;
             constraints = input.ConstraintEdges;
@@ -1418,7 +1460,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         private static readonly TUtils utils = default;
 
-        public void Triangulate(InputData<T2> input, OutputData<T2> output, Args args, Allocator allocator)
+        public void Triangulate(NativeInputData<T2> input, NativeOutputData<T2> output, Args args, Allocator allocator)
         {
             var tmpStatus = default(NativeReference<Status>);
             var tmpPositions = default(NativeList<T2>);
@@ -1454,17 +1496,17 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             if (tmpIgnoredHalfedgesForPlantingSeeds.IsCreated) tmpIgnoredHalfedgesForPlantingSeeds.Dispose();
         }
 
-        public void PlantHoleSeeds(InputData<T2> input, OutputData<T2> output, Args args, Allocator allocator)
+        public void PlantHoleSeeds(NativeInputData<T2> input, NativeOutputData<T2> output, Args args, Allocator allocator)
         {
             new PlantingSeedStep(input, output, args).Execute(allocator, true);
         }
 
-        public void RefineMesh(OutputData<T2> output, Allocator allocator, T area2Threshold, T angleThreshold, T shells, bool constrainBoundary = false)
+        public void RefineMesh(NativeOutputData<T2> output, Allocator allocator, T area2Threshold, T angleThreshold, T shells, bool constrainBoundary = false)
         {
             new RefineMeshStep(output, area2Threshold, angleThreshold, shells).Execute(allocator, refineMesh: true, constrainBoundary);
         }
 
-        public void DynamicInsertPoint(OutputData<T2> output, int tId, T2 p, Allocator allocator)
+        public void DynamicInsertPoint(NativeOutputData<T2> output, int tId, T2 p, Allocator allocator)
         {
             using var pathHalfedges = new NativeList<int>(allocator);
             using var pathPoints = new NativeList<int>(allocator);
@@ -1482,7 +1524,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }.UnsafeInsertPointBulk(p, tId);
         }
 
-        public void DynamicSplitHalfedge(OutputData<T2> output, int he, T alpha, Allocator allocator)
+        public void DynamicSplitHalfedge(NativeOutputData<T2> output, int he, T alpha, Allocator allocator)
         {
             using var pathHalfedges = new NativeList<int>(allocator);
             using var pathPoints = new NativeList<int>(allocator);
@@ -1558,7 +1600,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
         }
 
-        public void DynamicRemoveBulkPoint(OutputData<T2> output, int pId, Allocator allocator)
+        public void DynamicRemoveBulkPoint(NativeOutputData<T2> output, int pId, Allocator allocator)
         {
             /// This utility removes the specified point `pId`. It is designed specifically for handling bulk points only!
             ///
@@ -1600,7 +1642,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             AdaptPoints(output, pId);
         }
 
-        private static void BuildHeLoop(OutputData<T2> output, NativeList<int> heLoop, int pId)
+        private static void BuildHeLoop(NativeOutputData<T2> output, NativeList<int> heLoop, int pId)
         {
             var h0 = -1;
             /// NOTE: This can be optimized to an O(1) operation by introducing a `pointToHalfedge` buffer.
@@ -1630,7 +1672,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
         }
 
-        private static void BuildLoops(OutputData<T2> output, NativeList<int> heLoop, NativeArray<bool> visitedTriangles, NativeArray<int> pIdLoop, NativeArray<int> oheLoop, NativeArray<bool> oheConstrained, out int tIdMinVisited)
+        private static void BuildLoops(NativeOutputData<T2> output, NativeList<int> heLoop, NativeArray<bool> visitedTriangles, NativeArray<int> pIdLoop, NativeArray<int> oheLoop, NativeArray<bool> oheConstrained, out int tIdMinVisited)
         {
             tIdMinVisited = int.MaxValue;
             for (int i = 0; i < heLoop.Length; i++)
@@ -1644,7 +1686,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
         }
 
-        private static void RemoveTriangles(OutputData<T2> output, NativeArray<bool> visitedTriangles, int tIdMinVisited, NativeArray<int> halfedgeLoop)
+        private static void RemoveTriangles(NativeOutputData<T2> output, NativeArray<bool> visitedTriangles, int tIdMinVisited, NativeArray<int> halfedgeLoop)
         {
             static void DisableHe(NativeList<int> halfedges, int he, int rId)
             {
@@ -1705,7 +1747,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             halfedges.Length = 3 * wId;
         }
 
-        private static void TriangulateCavity(OutputData<T2> output, NativeArray<int> pIdLoop, NativeList<int> cavityTriangles, NativeList<int> cavityHalfedges, Allocator allocator)
+        private static void TriangulateCavity(NativeOutputData<T2> output, NativeArray<int> pIdLoop, NativeList<int> cavityTriangles, NativeList<int> cavityHalfedges, Allocator allocator)
         {
             using var cavityPositions = new NativeArray<T2>(pIdLoop.Length, allocator);
             using var cavityConstraints = new NativeArray<int>(2 * pIdLoop.Length, allocator);
@@ -1735,7 +1777,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             );
         }
 
-        private static void MergeTriangulations(OutputData<T2> output, NativeArray<int> pIdLoop, NativeList<int> cavityTriangles, NativeList<int> cavityHalfedges, NativeArray<int> oheLoop, NativeArray<bool> oheConstrained)
+        private static void MergeTriangulations(NativeOutputData<T2> output, NativeArray<int> pIdLoop, NativeList<int> cavityTriangles, NativeList<int> cavityHalfedges, NativeArray<int> oheLoop, NativeArray<bool> oheConstrained)
         {
             output.ConstrainedHalfedges.Length += cavityHalfedges.Length;
 
@@ -1769,7 +1811,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             output.Halfedges.AddRange(cavityHalfedges.AsArray());
         }
 
-        private static void AdaptPoints(OutputData<T2> output, int pId)
+        private static void AdaptPoints(NativeOutputData<T2> output, int pId)
         {
             output.Positions.RemoveAt(pId);
 
@@ -1781,7 +1823,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
         }
 
-        private void PreProcessInputStep(InputData<T2> input, OutputData<T2> output, Args args, out NativeArray<T2> localHoles, out TTransform lt, Allocator allocator)
+        private void PreProcessInputStep(NativeInputData<T2> input, NativeOutputData<T2> output, Args args, out NativeArray<T2> localHoles, out TTransform lt, Allocator allocator)
         {
             using var _ = Markers.PreProcessInputStep.Auto();
 
@@ -1813,7 +1855,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             }
         }
 
-        private void PostProcessInputStep(OutputData<T2> output, Args args, TTransform lt)
+        private void PostProcessInputStep(NativeOutputData<T2> output, Args args, TTransform lt)
         {
             if (args.Preprocessor == Preprocessor.None)
             {
@@ -1837,7 +1879,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private NativeArray<T2>.ReadOnly holes;
             private NativeArray<bool>.ReadOnly ignoredConstraints;
 
-            public ValidateInputStep(InputData<T2> input, OutputData<T2> output, Args args)
+            public ValidateInputStep(NativeInputData<T2> input, NativeOutputData<T2> output, Args args)
             {
                 positions = output.Positions.AsReadOnly();
                 status = output.Status;
@@ -2109,7 +2151,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private int hullStart;
             private int trianglesLen;
 
-            public DelaunayTriangulationStep(OutputData<T2> output, Args args)
+            public DelaunayTriangulationStep(NativeOutputData<T2> output, Args args)
             {
                 status = output.Status;
                 positions = output.Positions.AsReadOnly();
@@ -2494,7 +2536,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private NativeList<int> unresolvedIntersections;
             private NativeArray<int> pointToHalfedge;
 
-            public ConstrainEdgesStep(InputData<T2> input, OutputData<T2> output, Args args)
+            public ConstrainEdgesStep(NativeInputData<T2> input, NativeOutputData<T2> output, Args args)
             {
                 status = output.Status;
                 positions = output.Positions.AsReadOnly();
@@ -2872,9 +2914,9 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private readonly Args args;
             private int tIdMinVisited;
 
-            public PlantingSeedStep(InputData<T2> input, OutputData<T2> output, Args args) : this(output, args, input.HoleSeeds) { }
+            public PlantingSeedStep(NativeInputData<T2> input, NativeOutputData<T2> output, Args args) : this(output, args, input.HoleSeeds) { }
 
-            public PlantingSeedStep(OutputData<T2> output, Args args, NativeArray<T2> localHoles)
+            public PlantingSeedStep(NativeOutputData<T2> output, Args args, NativeArray<T2> localHoles)
             {
                 status = output.Status;
                 triangles = output.Triangles;
@@ -3180,13 +3222,13 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
             private readonly T maximumArea2, angleThreshold, shells;
             private readonly int initialPointsCount;
 
-            public RefineMeshStep(OutputData<T2> output, Args args, TTransform lt) : this(output,
+            public RefineMeshStep(NativeOutputData<T2> output, Args args, TTransform lt) : this(output,
                 area2Threshold: utils.Cast(utils.mul(utils.Cast(utils.mul(utils.Const(2), utils.Const(args.RefinementThresholdArea))), lt.AreaScalingFactor)),
                 angleThreshold: utils.Const(args.RefinementThresholdAngle),
                 shells: utils.Const(args.ConcentricShellsParameter))
             { }
 
-            public RefineMeshStep(OutputData<T2> output, T area2Threshold, T angleThreshold, T shells)
+            public RefineMeshStep(NativeOutputData<T2> output, T area2Threshold, T angleThreshold, T shells)
             {
                 status = output.Status;
                 initialPointsCount = output.Positions.Length;
@@ -3484,7 +3526,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
             public struct UnsafeBowerWatson
             {
-                public OutputData<T2> Output;
+                public NativeOutputData<T2> Output;
                 public NativeList<Circle> Circles;
 
                 public NativeQueueList<int> TrianglesQueue;

--- a/Tests/TestUtils.cs
+++ b/Tests/TestUtils.cs
@@ -10,7 +10,9 @@ using Unity.Jobs;
 using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.TestTools.Utils;
-#if UNITY_MATHEMATICS_FIXEDPOINT 
+using andywiecko.BurstTriangulator.LowLevel.Unsafe;
+
+#if UNITY_MATHEMATICS_FIXEDPOINT
 using Unity.Mathematics.FixedPoint;
 #endif
 
@@ -175,11 +177,9 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
 #endif
             _ => (float2)(dynamic)v,
         };
-        public static void Triangulate<T>(this LowLevel.Unsafe.UnsafeTriangulator<T> triangulator, LowLevel.Unsafe.InputData<T> input, LowLevel.Unsafe.OutputData<T> output, LowLevel.Unsafe.Args args, Allocator allocator) where T : unmanaged =>
-            LowLevel.Unsafe.Extensions.Triangulate((dynamic)triangulator, (dynamic)input, (dynamic)output, args, allocator);
-        public static void PlantHoleSeeds<T>(this LowLevel.Unsafe.UnsafeTriangulator<T> triangulator, LowLevel.Unsafe.InputData<T> input, LowLevel.Unsafe.OutputData<T> output, LowLevel.Unsafe.Args args, Allocator allocator) where T : unmanaged =>
-            LowLevel.Unsafe.Extensions.PlantHoleSeeds((dynamic)triangulator, (dynamic)input, (dynamic)output, args, allocator);
-        public static void DynamicInsertPoint<T2, T3>(this LowLevel.Unsafe.UnsafeTriangulator<T2> triangulator, LowLevel.Unsafe.OutputData<T2> output, int tId, T3 bar, Allocator allocator) where T2 : unmanaged where T3 : unmanaged => LowLevel.Unsafe.Extensions.DynamicInsertPoint((dynamic)triangulator, (dynamic)output, tId, default(T2) switch
+        public static void Triangulate<T>(this UnsafeTriangulator<T> triangulator, NativeInputData<T> input, NativeOutputData<T> output, Args args, Allocator allocator) where T : unmanaged => LowLevel.Unsafe.Extensions.Triangulate((dynamic)triangulator, (dynamic)input, (dynamic)output, args, allocator);
+        public static void PlantHoleSeeds<T>(this UnsafeTriangulator<T> triangulator, NativeInputData<T> input, NativeOutputData<T> output, Args args, Allocator allocator) where T : unmanaged => LowLevel.Unsafe.Extensions.PlantHoleSeeds((dynamic)triangulator, (dynamic)input, (dynamic)output, args, allocator);
+        public static void DynamicInsertPoint<T2, T3>(this UnsafeTriangulator<T2> triangulator, NativeOutputData<T2> output, int tId, T3 bar, Allocator allocator) where T2 : unmanaged where T3 : unmanaged => LowLevel.Unsafe.Extensions.DynamicInsertPoint((dynamic)triangulator, (dynamic)output, tId, default(T2) switch
         {
 #if UNITY_MATHEMATICS_FIXEDPOINT
             fp2 => new fp3((fp)((dynamic)bar).x, (fp)((dynamic)bar).y, (fp)((dynamic)bar).z),
@@ -187,14 +187,14 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             _ => (dynamic)bar
         },
             allocator);
-        public static void DynamicSplitHalfedge<T2>(this LowLevel.Unsafe.UnsafeTriangulator<T2> triangulator, LowLevel.Unsafe.OutputData<T2> output, int he, float alpha, Allocator allocator) where T2 : unmanaged => LowLevel.Unsafe.Extensions.DynamicSplitHalfedge((dynamic)triangulator, (dynamic)output, he, default(T2) switch
+        public static void DynamicSplitHalfedge<T2>(this UnsafeTriangulator<T2> triangulator, NativeOutputData<T2> output, int he, float alpha, Allocator allocator) where T2 : unmanaged => LowLevel.Unsafe.Extensions.DynamicSplitHalfedge((dynamic)triangulator, (dynamic)output, he, default(T2) switch
         {
 #if UNITY_MATHEMATICS_FIXEDPOINT
             fp2 => (fp)alpha,
 #endif
             _ => (dynamic)alpha,
         }, allocator);
-        public static void DynamicRemoveBulkPoint<T>(this LowLevel.Unsafe.UnsafeTriangulator<T> triangulator, LowLevel.Unsafe.OutputData<T> output, int pId, Allocator allocator) where T : unmanaged => LowLevel.Unsafe.Extensions.DynamicRemoveBulkPoint((dynamic)triangulator, (dynamic)output, pId, allocator);
+        public static void DynamicRemoveBulkPoint<T>(this UnsafeTriangulator<T> triangulator, NativeOutputData<T> output, int pId, Allocator allocator) where T : unmanaged => LowLevel.Unsafe.Extensions.DynamicRemoveBulkPoint((dynamic)triangulator, (dynamic)output, pId, allocator);
         public static void Run<T>(this Triangulator<T> triangulator) where T : unmanaged =>
             Extensions.Run((dynamic)triangulator);
         public static JobHandle Schedule<T>(this Triangulator<T> triangulator, JobHandle dependencies = default) where T : unmanaged =>

--- a/Tests/UnsafeTriangulatorEditorTests.cs
+++ b/Tests/UnsafeTriangulatorEditorTests.cs
@@ -223,7 +223,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         public void UnsafeTriangulatorPlantHoleSeedsAutoTest()
         {
             var t = new UnsafeTriangulator<T>();
-            var input = new LowLevel.Unsafe.InputData<T>()
+            var input = new NativeInputData<T>()
             {
                 Positions = LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>().AsNativeArray(out var h1),
                 ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(out var h2),
@@ -249,7 +249,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         public void UnsafeTriangulatorPlantHoleSeedsRestoreBoundaryTest()
         {
             var t = new UnsafeTriangulator<T>();
-            var input = new LowLevel.Unsafe.InputData<T>()
+            var input = new NativeInputData<T>()
             {
                 Positions = LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>().AsNativeArray(out var h1),
                 ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(out var h2),
@@ -275,7 +275,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         public void UnsafeTriangulatorPlantHoleSeedsHolesTest()
         {
             var t = new UnsafeTriangulator<T>();
-            var inputWithHoles = new LowLevel.Unsafe.InputData<T>()
+            var inputWithHoles = new NativeInputData<T>()
             {
                 Positions = LakeSuperior.Points.Scale(1000, typeof(T) == typeof(int2)).DynamicCast<T>().AsNativeArray(out var h1),
                 ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(out var h2),
@@ -428,7 +428,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         public void UnsafeTriangulatorRefineMeshTest()
         {
             var t = new UnsafeTriangulator<T>();
-            var input = new LowLevel.Unsafe.InputData<T>()
+            var input = new NativeInputData<T>()
             {
                 Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(out var h1),
             };
@@ -440,7 +440,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             using var halfedges = new NativeList<int>(Allocator.Persistent);
             using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
             using var outputPositions = new NativeList<T>(Allocator.Persistent);
-            var output = new LowLevel.Unsafe.OutputData<T>
+            var output = new NativeOutputData<T>
             {
                 Triangles = triangles2,
                 Halfedges = halfedges,
@@ -459,7 +459,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         public void UnsafeTriangulatorRefineMeshConstrainedTest()
         {
             var t = new UnsafeTriangulator<T>();
-            var input = new LowLevel.Unsafe.InputData<T>()
+            var input = new NativeInputData<T>()
             {
                 Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(out var h1),
                 ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(out var h2),
@@ -473,7 +473,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             using var halfedges = new NativeList<int>(Allocator.Persistent);
             using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
             using var outputPositions = new NativeList<T>(Allocator.Persistent);
-            var output = new LowLevel.Unsafe.OutputData<T>
+            var output = new NativeOutputData<T>
             {
                 Triangles = triangles2,
                 Halfedges = halfedges,
@@ -493,7 +493,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
         public void UnsafeTriangulatorPlantHoleSeedsRefineMeshTest()
         {
             var t = new UnsafeTriangulator<T>();
-            var inputWithHoles = new LowLevel.Unsafe.InputData<T>()
+            var inputWithHoles = new NativeInputData<T>()
             {
                 Positions = LakeSuperior.Points.DynamicCast<T>().AsNativeArray(out var h1),
                 ConstraintEdges = LakeSuperior.Constraints.AsNativeArray(out var h2),
@@ -510,7 +510,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             using var outputPositions = new NativeList<T>(Allocator.Persistent);
             using var halfedges = new NativeList<int>(Allocator.Persistent);
             using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
-            var output = new LowLevel.Unsafe.OutputData<T> { Triangles = triangles2, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges, Positions = outputPositions };
+            var output = new NativeOutputData<T> { Triangles = triangles2, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges, Positions = outputPositions };
             t.Triangulate(inputWithoutHoles, output, args.With(refineMesh: false), Allocator.Persistent);
             t.PlantHoleSeeds(inputWithHoles, output, args, Allocator.Persistent);
             LowLevel.Unsafe.Extensions.RefineMesh((dynamic)t, (dynamic)output, Allocator.Persistent);
@@ -550,8 +550,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             using var halfedges = new NativeList<int>(Allocator.Persistent);
             using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
             using var constraints = new NativeArray<int>(managedConstraints, Allocator.Persistent);
-            var input = new LowLevel.Unsafe.InputData<T> { Positions = positions, ConstraintEdges = constraints };
-            var output = new LowLevel.Unsafe.OutputData<T> { Positions = outputPositions, Triangles = triangles, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges };
+            var input = new NativeInputData<T> { Positions = positions, ConstraintEdges = constraints };
+            var output = new NativeOutputData<T> { Positions = outputPositions, Triangles = triangles, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges };
 
             int FindTriangle(ReadOnlySpan<int> initialTriangles, int j)
             {
@@ -612,8 +612,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             using var halfedges = new NativeList<int>(Allocator.Persistent);
             using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
             using var constraints = new NativeArray<int>(managedConstraints, Allocator.Persistent);
-            var input = new LowLevel.Unsafe.InputData<T> { Positions = positions, ConstraintEdges = constraints };
-            var output = new LowLevel.Unsafe.OutputData<T> { Positions = outputPositions, Triangles = triangles, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges };
+            var input = new NativeInputData<T> { Positions = positions, ConstraintEdges = constraints };
+            var output = new NativeOutputData<T> { Positions = outputPositions, Triangles = triangles, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges };
 
             t.Triangulate(input, output, args: Args.Default(), Allocator.Persistent);
             TestUtils.Draw(outputPositions.AsReadOnly().CastToFloat2(), triangles.AsReadOnly(), Color.red, duration: 5f);
@@ -686,8 +686,8 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             using var halfedges = new NativeList<int>(Allocator.Persistent);
             using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
             using var constraints = new NativeArray<int>(managedConstraints, Allocator.Persistent);
-            var input = new LowLevel.Unsafe.InputData<T> { Positions = positions, ConstraintEdges = constraints };
-            var output = new LowLevel.Unsafe.OutputData<T> { Positions = outputPositions, Triangles = triangles, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges };
+            var input = new NativeInputData<T> { Positions = positions, ConstraintEdges = constraints };
+            var output = new NativeOutputData<T> { Positions = outputPositions, Triangles = triangles, Halfedges = halfedges, ConstrainedHalfedges = constrainedHalfedges };
 
             t.Triangulate(input, output, args: Args.Default(autoHolesAndBoundary: true), Allocator.Persistent);
             TestUtils.Draw(outputPositions.AsReadOnly().CastToFloat2(), triangles.AsReadOnly(), Color.red, duration: 5f);
@@ -935,7 +935,7 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             using var constrainedHalfedges = new NativeList<bool>(Allocator.Persistent);
             using var halfedges = new NativeList<int>(Allocator.Persistent);
 
-            var output = new LowLevel.Unsafe.OutputData<T> { Positions = outputPositions, Triangles = triangles, ConstrainedHalfedges = constrainedHalfedges, Halfedges = halfedges };
+            var output = new NativeOutputData<T> { Positions = outputPositions, Triangles = triangles, ConstrainedHalfedges = constrainedHalfedges, Halfedges = halfedges };
 
             t.Triangulate(
                 input: new() { Positions = inputPositions, ConstraintEdges = constraints },


### PR DESCRIPTION
Introduce `NativeInputData` and `NativeOutputData` to eliminate ambiguity between `andywiecko.BurstTriangulator.Input/OutputData<T>` and `andywiecko.BurstTriangulator.LowLevel.Unsafe.Input/OutputData<T>`. The latter, located in `LowLevel.Unsafe`, have now been marked with the `Obsolete` attribute and includes an implicit cast to the newly introduced `NativeInputData` and `NativeOutputData`.