### PR TITLE
fix: support for empty positions with preprocessors

### DIFF
--- a/Runtime/Triangulator.cs
+++ b/Runtime/Triangulator.cs
@@ -5637,6 +5637,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public readonly TransformFloat CalculateLocalTransformation(NativeArray<float2> positions)
         {
+            if (positions.Length == 0) return Identity;
             var (min, max) = BoundingBox(positions);
             var com = float2.zero;
             foreach (var p in positions)
@@ -5739,6 +5740,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public readonly TransformDouble CalculateLocalTransformation(NativeArray<double2> positions)
         {
+            if (positions.Length == 0) return Identity;
             var (min, max) = BoundingBox(positions);
             var com = double2.zero;
             foreach (var p in positions)
@@ -5801,14 +5803,15 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public readonly TransformInt CalculateLocalTransformation(NativeArray<int2> positions)
         {
-            var (min, max) = BoundingBox(positions);
+            if (positions.Length == 0) return Identity;
             var com = int2.zero;
             foreach (var p in positions)
             {
                 com += p;
             }
+            com /= positions.Length;
 
-            return new(-com / positions.Length);
+            return new(-com);
         }
     }
 
@@ -5838,6 +5841,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public readonly TransformFp CalculatePCATransformation(NativeArray<fp2> positions)
         {
+            if (positions.Length == 0) return Identity;
             var com = (fp2)0;
             foreach (var p in positions)
             {
@@ -5873,6 +5877,7 @@ namespace andywiecko.BurstTriangulator.LowLevel.Unsafe
 
         public readonly TransformFp CalculateLocalTransformation(NativeArray<fp2> positions)
         {
+            if (positions.Length == 0) return Identity;
             var (min, max) = BoundingBox(positions);
             var com = fp2.zero;
             foreach (var p in positions)

--- a/Tests/TriangulatorGenericsEditorTests.cs
+++ b/Tests/TriangulatorGenericsEditorTests.cs
@@ -85,6 +85,24 @@ namespace andywiecko.BurstTriangulator.Editor.Tests
             _ => RunState.Runnable,
         };
 
+        [Test, Description("Verify that the only error for triangulation with an empty position input is the ERR_INPUT_POSITIONS_LENGTH error code.")]
+        public void EmptyInputPositionsTest([Values] Preprocessor preprocessor)
+        {
+            if (typeof(T) == typeof(int2) && preprocessor == Preprocessor.PCA)
+            {
+                Assert.Ignore($"{nameof(Preprocessor)}.{nameof(Preprocessor.PCA)} is not supported by {nameof(int2)}");
+            }
+
+            using var positions = new NativeArray<T>(Array.Empty<T>(), Allocator.Persistent);
+            using var triangulator = new Triangulator<T>(Allocator.Persistent)
+            {
+                Input = { Positions = positions },
+                Settings = { ValidateInput = true, Verbose = false, Preprocessor = preprocessor }
+            };
+            triangulator.Run();
+            Assert.That(triangulator.Output.Status.Value, Is.EqualTo(Status.ERR_INPUT_POSITIONS_LENGTH));
+        }
+
         [Test]
         public void DelaunayTriangulationWithoutRefinementTest()
         {


### PR DESCRIPTION
Introduced with `Utilities.BoundingBox`.